### PR TITLE
build lanelet2 ready for release and packaging

### DIFF
--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -29,8 +29,13 @@ install_lanelet2_python38()
     mkdir -p $REPO_DIR/catkin_ws/src
     ln -sfn $REPO_DIR/Lanelet2 $REPO_DIR/catkin_ws/src/Lanelet2
     cd $REPO_DIR/catkin_ws
-    catkin init
-    catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPYTHON_VERSION=3.8
+    export DESTDIR="$REPO_DIR/catkin_ws/install"
+    catkin init --workspace $REPO_DIR/catkin_ws
+    catkin config --workspace $REPO_DIR/catkin_ws \
+                  --install \
+                  -i /opt/ros/lanelet2 \
+                  --cmake-args -DCMAKE_BUILD_TYPE=Release -DPYTHON_VERSION=3.8 \
+                  -DTARGET_INSTALL_DIR="/opt/ros/lanelet2" > /dev/null
     pip3 -q install catkin_pkg rospkg
     catkin build --workspace $REPO_DIR/catkin_ws
 }


### PR DESCRIPTION
In addition to normal development build, configure the catkin workspace to perform the install build with the target location `/opt/ros/lanelet2`.

# Testing
1. Clean existing workspaces:
```
$ cd anm_unreal_sim
$ rm -rf .catkin_tools
$ cd submodules/geoscenarioserver
$ rm -rf catkin_ws
```
2. Run the build
```
$ bash scripts/install_dependencies.bash
```
3. It should have created the folder `catkin_ws/install/opt/ros/lanelet2` workspace containing `setup.bash`.
4. Move the workspace to the target location
```
$ sudo mv catkin_ws/install/opt/ros/lanelet2/ /opt/ros
```
5. Check PYTHONPATH before and after sourcing:
```
$ echo $PYTHONPATH 
/opt/ros/road-demo/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages
$ source /opt/ros/lanelet2/setup.bash 
$ echo $PYTHONPATH 
/opt/ros/lanelet2/lib/python3/dist-packages:/opt/ros/melodic/lib/python3/dist-packages:/opt/ros/road-demo/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages
```
6. Verify the library can be loaded in Python3.8
```
$ python3.8
>>> import lanelet2
>>> 
```
No error should be displayed.