### PR TITLE
catkin init Now Uses CWD as Workspace

### DIFF
--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -31,13 +31,12 @@ install_lanelet2_python38()
     cd $REPO_DIR/catkin_ws
     catkin init --workspace .
     export DESTDIR="$REPO_DIR/catkin_ws/install"
-    catkin config --workspace $REPO_DIR/catkin_ws \
-                  --install \
+    catkin config --install \
                   -i /opt/ros/lanelet2 \
                   --cmake-args -DCMAKE_BUILD_TYPE=Release -DPYTHON_VERSION=3.8 \
                   -DTARGET_INSTALL_DIR="/opt/ros/lanelet2" > /dev/null
     pip3 -q install catkin_pkg rospkg
-    catkin build --workspace $REPO_DIR/catkin_ws
+    catkin build
 }
 
 install_lanelet2_binary()


### PR DESCRIPTION
This PR changes the `catkin init` command in `install_dependencies.bash`:
I did some testing and found that
```
$ cd ~/anm_unreal_sim/submodules/geoscenarioserver/catkin_ws
$ catkin init --workspace ~/anm_unreal_sim/submodules/geoscenarioserver/catkin_ws
```
(which is currently what is being done in `install_dependencies.bash`) tries to do `catkin init` for `$HOME/anm_unreal_sim`, which is not what we want. However,
```
$ cd ~/anm_unreal_sim/submodules/geoscenarioserver/catkin_ws
$ catkin init --workspace .
```
works correctly -- it initializes the `geoscenarioserver/catkin_ws` workspace.