### PR TITLE
GSServer -m map path parameter

### DIFF
--- a/GSServer.py
+++ b/GSServer.py
@@ -22,7 +22,7 @@ def start_server(args, m=MVelKeepConfig()):
     lanelet_map = LaneletMap()
     sim_config = SimConfig()
     traffic = SimTraffic(lanelet_map, sim_config)
-    if args.verify_map == "":
+    if args.verify_map != "":
         verify_map_file(args.verify_map, lanelet_map)
         return
 

--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -39,7 +39,7 @@ def load_geoscenario_from_file(gsfile, sim_traffic:SimTraffic, sim_config:SimCon
         sim_config.plot_vid = parser.globalconfig.tags['plotvid']
 
     #========= Map
-    if map_path != "":
+    if map_path == "":
         map_file = os.path.join(ROOT_DIR, 'scenarios', parser.globalconfig.tags['lanelet']) #use default map path
     else:
         map_file = os.path.join(map_path, parser.globalconfig.tags['lanelet']) #use parameter map path


### PR DESCRIPTION
added -m parameter

Testing:
With parameter:
`
python3.8 /home/ae/anm_unreal_sim/submodules/geoscenarioserver/GSServer.py --scenario /home/ae/anm_unreal_test_suite/scenarios/ring_road_ccw/geoscenarioserver/ring_road_ccw.osm --map-path /home/ae/anm_unreal_test_suite/maps

*GSS server runs with 10 updating VIDS
`
Without parameter:
`
python3.8 /home/ae/anm_unreal_sim/submodules/geoscenarioserver/GSServer.py --scenario /home/ae/anm_unreal_test_suite/scenarios/ring_road_ccw/geoscenarioserver/ring_road_ccw.osm

RuntimeError: Could not find lanelet map under /home/ae/anm_unreal_sim/submodules/geoscenarioserver/scenarios/ring_road/lanelet2/ringroad.osm
`
These files aren't implemented here yet, so this makes sense.