### PR TITLE
Btree organization Old

### DIFF
--- a/btrees/sp/drive.btree
+++ b/btrees/sp/drive.btree
@@ -1,0 +1,12 @@
+behaviortree drive_tree:
+    ?
+        ->
+            condition c_goal ( reached_goal( threshold=35 ) )
+            maneuver m_stop_goal ( MStopConfig(type=2) )
+        ->
+            condition c_redlight ( traffic_light_red( threshold=40 ) )
+            maneuver m_stop_redlight ( MStopConfig( type=3 ) )
+        ->
+            condition c_busy_lane( lane_occupied() )
+            maneuver m_follow_lead ( MFollowConfig() )
+        maneuver m_keepvelocity ( MVelKeepConfig(vel=MP(14.0,10,6)) )

--- a/btrees/sv/drive.btree
+++ b/btrees/sv/drive.btree
@@ -1,0 +1,12 @@
+behaviortree drive_tree:
+    ?
+        ->
+            condition c_goal ( reached_goal( threshold=35 ) )
+            maneuver m_stop_goal ( MStopConfig(type=2) )
+        ->
+            condition c_redlight ( traffic_light_red( threshold=40 ) )
+            maneuver m_stop_redlight ( MStopConfig( type=3 ) )
+        ->
+            condition c_busy_lane( lane_occupied() )
+            maneuver m_follow_lead ( MFollowConfig() )
+        maneuver m_keepvelocity ( MVelKeepConfig(vel=MP(14.0,10,6)) )

--- a/btrees/sv/eval_drive.btree
+++ b/btrees/sv/eval_drive.btree
@@ -1,0 +1,6 @@
+behaviortree eval_drive:
+    ?
+        ->
+            condition c_vehicle_ahead( lane_occupied() )
+            maneuver m_follow_lead ( MFollowConfig() )
+        maneuver m_vkeeping ( MVelKeepConfig(vel=MP(16.0,10,6)) )

--- a/btrees/sv/eval_main.btree
+++ b/btrees/sv/eval_main.btree
@@ -1,0 +1,12 @@
+behaviortree eval_main:
+    ?
+    	->
+            condition c_redlight ( traffic_light_red(threshold=20 ) )
+            maneuver m_stop_redlight ( MStopConfig( type=3 , distance = 0.0) )
+        ->
+            condition c_green_light ( traffic_light_green(threshold=20 ) )
+            ?
+                condition c_wait ( wait( time=0.01) )
+                subtree eval_drive
+        subtree eval_drive
+

--- a/btrees/sv/lanechange.btree
+++ b/btrees/sv/lanechange.btree
@@ -1,0 +1,6 @@
+behaviortree lanechange:
+    ?
+        ->
+            condition c_should_cutin( should_cutin(target_lane_id=-1) )
+            maneuver m_cutin( MCutInConfig(target_lid=-1) )
+        maneuver m_lane_swerve( MLaneSwerveConfig(target_lid=-1) )

--- a/btrees/sv/st_drivefast.btree
+++ b/btrees/sv/st_drivefast.btree
@@ -1,0 +1,3 @@
+behaviortree st_driveslow:
+    ->
+        subtree drive( m_keepvelocity=MVelKeepConfig(vel=MP(16, 10, 6),max_diff=12.0) )

--- a/btrees/sv/st_driveslow.btree
+++ b/btrees/sv/st_driveslow.btree
@@ -1,0 +1,3 @@
+behaviortree st_driveslow:
+    ->
+        subtree drive( m_keepvelocity=MVelKeepConfig(vel=MP(10, 10, 6)) )

--- a/btrees/sv/st_lanechange.btree
+++ b/btrees/sv/st_lanechange.btree
@@ -1,0 +1,6 @@
+behaviortree st_lanechange:
+    ?
+        ->
+            condition lc( sim_time (repeat=False, tmin=3, tmax=10))
+            subtree lanechange()
+        subtree drive()

--- a/btrees/sv/st_reverse.btree
+++ b/btrees/sv/st_reverse.btree
@@ -1,0 +1,6 @@
+behaviortree reverse_tree:
+    ?
+        ->
+            condition c_goal ( reached_goal(reverse=True) )
+            maneuver m_stop_goal ( MStopConfig() )
+        maneuver m_reverse( MReverseConfig() )


### PR DESCRIPTION
This PR copies the btree files and organises them by pedestrian or vehicle btrees. This will help for -b searching in the future.

Should the pedestrian drive be renamed to walk?

Testing:
Pulled https://github.com/wavelab/anm_unreal_test_suite/pull/90 onto anm_unreal_test_suite
`
$ source /opt/ros/lanelet2/setup.bash
$ python3.8 $HOME/anm_unreal_sim/submodules/geoscenarioserver/GSServer.py --scenario $HOME/anm_unreal_test_suite/scenarios/ring_road_ccw/geoscenarioserver/ring_road_ccw.osm --map-path $HOME/anm_unreal_test_suite/maps

*GSS server runs and 10 VIDs move
`
Without --map-path:
`
$ python3.8 $HOME/anm_unreal_sim/submodules/geoscenarioserver/GSServer.py --scenario $HOME/anm_unreal_test_suite/scenarios/ring_road_ccw/geoscenarioserver/ring_road_ccw.osm
...
RuntimeError: Could not find lanelet map under /home/ae/anm_unreal_sim/submodules/geoscenarioserver/scenarios/ring_road/lanelet2/ringroad.osm
`