### PR TITLE
Fix "task_delta_time" Not Defined Bug

### DIFF
--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -184,16 +184,12 @@ class SVPlanner(object):
                                             planner_state.pedestrians,
                                             planner_state.static_objects)
 
-                
-                if EVALUATION_MODE:
-                    if self.last_plan:
-                        sync_planner.end_task() #blocks if < target
-                        task_delta_time = sync_planner.get_task_time()
-                    else: #First plan. Does not block and return results asap.
-                        sync_planner.end_task(False) #blocks if < target
-                        task_delta_time = 0
-                else:
+                if self.last_plan:
                     sync_planner.end_task() #blocks if < target
+                    task_delta_time = sync_planner.get_task_time()
+                else: #First plan. Does not block and return results asap.
+                    sync_planner.end_task(False) #blocks if < target
+                    task_delta_time = 0
 
                 if frenet_traj is None:
                     log.warn("plan_maneuver return invalid trajectory.")


### PR DESCRIPTION
## Issue
- The planners crash when running WISE Sim and GSS with the following:
```sh
cd ~/anm_unreal_test_suite
slaunch ring_road_ccw
```
- In the simulation, and in the GSS dashboard, the vehicles don't move since the planners have crashed
- In `GeoScenarioServer.log`:
```
Process Process-6:$
Traceback (most recent call last):$
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap$
    self.run()$
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run$
    self._target(*self._args, **self._kwargs)$
  File "/opt/geoscenarioserver/sv/SDVPlanner.py", line 204, in run_planner_process$
    plan.start_time = state_time + task_delta_time$
UnboundLocalError: local variable 'task_delta_time' referenced before assignment$
```
- However, this doesn't happen when running:
```sh
cd ~/anm_unreal_sim/submodules/geoscenarioserver
python3.8 GSServer.py -s scenarios/test_scenarios/gs_ringroad_stress_loop.osm
```

## Solution
- The problem is that, in `sv/SDVPlanner.py`, `task_delta_time` depends on `EVALUATION_MODE` being set to `True` in `SimConfig.py`
- This change was made [here](https://github.com/rodrigoqueiroz/geoscenarioserver/pull/53/commits/424e821db543e26526dea929f5b8acc54e2c7df3#diff-44adee49fe0f00955a2608863528e7458c3cfdb5a6ac86f419ec102abb2f30c6R188) as a fix for Issue #56
- But, I don't think the `EVALUATION_MODE` check is necessary for the fix; just the part that checks if `self.last_plan` was set is needed for the fix

## Testing
- Modify `~/anm_unreal_sim/submodules/anm_sim_platform/scripts/launch.bash` for testing:

replace
```sh
gsserver="source /opt/ros/lanelet2/setup.bash --extend && /opt/geoscenarioserver/GSServer.py"
```
with
```sh
gsserver="source /opt/ros/lanelet2/setup.bash --extend && ${HOME}/anm_unreal_sim/submodules/geoscenarioserver/GSServer.py"
```
- Run WISE Sim and GSS:
```sh
cd ~/anm_unreal_test_suite
bash ~/anm_unreal_sim/submodules/anm_sim_platform/scripts/launch.bash ring_road_ccw
```
- You should see the vehicles moving in the simulator and in the server