### PR TITLE
Dashboard Pedestrians

### DIFF
--- a/SimConfig.py
+++ b/SimConfig.py
@@ -19,7 +19,7 @@ WAIT_FOR_INPUT = False      #wait for user input before starting simulation
 
 #Dash Config
 SHOW_DASHBOARD = True      	#show dash with plots, vehicles and trajectories. Optional.
-DASH_RATE = 30              #dash tick rate. Max is traffic rate.
+DASH_RATE = 10              #dash tick rate. Max is traffic rate.
 PLOT_VID = 1               	#vehicle to center the main plot around, if not defined by the scenario.
                             #Make sure there exists a vehicle with this id
 #Global Map


### PR DESCRIPTION
Added pedestrians to dashboard, with Cartesian chart when selected.

Testing:
```
$ slaunch ring_road_ccw
* no pedestrians or errors on dashboard as expected
$ cdgss
$ source /opt/ros/lanelet2/setup.bash --extend
$ ./GSServer.py -s scenarios/pedestrian_scenarios/gs_intersection_xwalk_signal.osm
*shows pedestrian and Cartesian chart

restart terminal.
$ cdts
checkout ring-road-pedestrian branch from https://github.com/wavelab/anm_unreal_test_suite/pull/97
$ slaunch rr_xwalk_intersection_basic
*can select pedestrian and other vehicles, and see Cartesian chart
```
Additional testing:
change vid 5 to vid 1 in `rr_xwalk_intersection_basic`:
$ slaunch rr_xwalk_intersection_basic
gives error:
`
File "/home/ae/anm_unreal_sim/submodules/geoscenarioserver/dash/Dashboard.py", line 162, in update_pedestrian_table
    self.tab.insert('', 'end', int(pid), values=(sp))
  File "/usr/lib/python3.8/tkinter/ttk.py", line 1365, in insert
    res = self.tk.call(self._w, "insert", parent, index,
_tkinter.TclError: Item 1 already exists
`
This bug has been fixed.

Next steps:
Putting pedestrians in another table will make the formatting cleaner.