### PR TITLE
Fix Stop Lines in Dashboard

### DIFF
--- a/dash/Dashboard.py
+++ b/dash/Dashboard.py
@@ -20,6 +20,7 @@ import glog as log
 from SimTraffic import *
 from SimConfig import *
 from util.Utils import *
+import sv.SDVPlannerState
 from sv.Vehicle import *
 from Actor import *
 from TrafficLight import *
@@ -342,7 +343,7 @@ class Dashboard(object):
 
         #re
         for re in regulatory_elements:
-            if isinstance(re, TrafficLightState):
+            if isinstance(re, sv.SDVPlannerState.TrafficLightState):
                 colorcode,_ = self.get_color_by_type('trafficlight',re.color)
                 x, y = re.stop_position
                 plt.axvline(x, color= colorcode, linestyle='-', zorder=0)


### PR DESCRIPTION
- Stop lines for traffic lights should appear in the frenet plot
- However, this stopped working in PR #58
- The reason is probably because [another TrafficLightState](https://github.com/rodrigoqueiroz/geoscenarioserver/blob/3a55cf0ae4de5db9f9517d5d17daa3347ebb40aa/sp/SPPlannerState.py#L17) was added which caused some conflict when using `if isinstance(re, TrafficLightState):`
- This has been fixed: `if isinstance(re, sv.SDVPlannerState.TrafficLightState):`

## Testing
```
python3.8 GSServer.py -s scenarios/test_scenarios/gs_intersection_greenlight.osm
python3.8 GSServer.py -s scenarios/test_scenarios/gs_intersection_redlight_follow.osm
python3.8 GSServer.py -s scenarios/test_scenarios/gs_intersection_redlight.osm
```
- You should see the stop line in the frenet plot when the vehicles are at the traffic light

```
python3.8 GSServer.py -s scenarios/pedestrian_scenarios/gs_intersection_xwalk_signal.osm
```
- This is just to test that pedestrian scenarios with traffic lights (crosswalk lights) still work
- Note: there won't be anything in the frenet plot