### PR TITLE
Fix typo in pedestrian behaviour trees

### DIFF
--- a/btrees/sp/walk.btree
+++ b/btrees/sp/walk.btree
@@ -19,6 +19,6 @@ behaviortree walk:
                             subtree cross_xwalk_before_red()
                         maneuver m_enter_crosswalk ( MEnterCrosswalkConfig() )
                 ->
-                    condition c_approaching_xwalk ( approaching_crosswalk() )
+                    condition c_approaching_crosswalk ( approaching_crosswalk() )
                     maneuver m_select_xwalk_by_light ( MSelectCrosswalkByLightConfig( aggressiveness_level=2 ) )
         maneuver m_keep_in_lane ( MKeepInLaneConfig( vel=MP(1.0,30,6) ) )

--- a/btrees/sp/walk_aggressiveness_level_1.btree
+++ b/btrees/sp/walk_aggressiveness_level_1.btree
@@ -19,6 +19,6 @@ behaviortree walk_aggressiveness_level_low:
                             subtree enter_xwalk_on_green()
                         maneuver m_enter_crosswalk ( MEnterCrosswalkConfig() )
                 ->
-                    condition c_approaching_xwalk ( approaching_crosswalk( threshold=3 ) )
+                    condition c_approaching_crosswalk ( approaching_crosswalk( threshold=3 ) )
                     maneuver m_select_xwalk_by_light ( MSelectCrosswalkByLightConfig( aggressiveness_level=1 ) )
         maneuver m_keep_in_lane ( MKeepInLaneConfig( vel=MP(1.0,30,6) ) )

--- a/btrees/sp/walk_aggressiveness_level_2.btree
+++ b/btrees/sp/walk_aggressiveness_level_2.btree
@@ -19,6 +19,6 @@ behaviortree walk_aggressiveness_level_med:
                             subtree cross_xwalk_before_red()
                         maneuver m_enter_crosswalk ( MEnterCrosswalkConfig() )
                 ->
-                    condition c_approaching_xwalk ( approaching_crosswalk( threshold=3 ) )
+                    condition c_approaching_crosswalk ( approaching_crosswalk( threshold=3 ) )
                     maneuver m_select_xwalk_by_light ( MSelectCrosswalkByLightConfig( aggressiveness_level=2 ) )
         maneuver m_keep_in_lane ( MKeepInLaneConfig( vel=MP(1.0,30,6) ) )

--- a/btrees/sp/walk_aggressiveness_level_3.btree
+++ b/btrees/sp/walk_aggressiveness_level_3.btree
@@ -19,6 +19,6 @@ behaviortree walk_aggressiveness_level_high:
                             subtree enter_xwalk_on_any_light_state()
                         maneuver m_enter_crosswalk ( MEnterCrosswalkConfig() )
                 ->
-                    condition c_approaching_xwalk ( approaching_crosswalk( threshold=3 ) )
+                    condition c_approaching_crosswalk ( approaching_crosswalk( threshold=3 ) )
                     maneuver m_select_xwalk_by_light ( MSelectCrosswalkByLightConfig( aggressiveness_level=3 ) )
         maneuver m_keep_in_lane ( MKeepInLaneConfig( vel=MP(1.0,30,6) ) )


### PR DESCRIPTION
Changed condition name from `c_approaching_xwalk` to `c_approaching_crosswalk` to be consistent with name in `sp/btree/BehaviorModels.py`

Files affected:
- `btrees/sp/walk.btree`
- `btrees/sp/walk_aggressiveness_level_*.btree`