### PR TITLE
fixed iintersection btree and added traffic light tests

### DIFF
--- a/scenarios/coretest_scenarios/tintersection_turnleft.gs.osm
+++ b/scenarios/coretest_scenarios/tintersection_turnleft.gs.osm
@@ -16,7 +16,7 @@
   </node>
   <node id='-5009670' action='modify' visible='true' lat='43.43528472732' lon='-80.57990521852' />
   <node id='-5009671' action='modify' visible='true' lat='43.43526860371' lon='-80.58015765097'>
-    <tag k='btree' v='standard_driver.btree' />
+    <tag k='btree' v='st_standard_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />
@@ -27,7 +27,7 @@
     <tag k='yaw' v='310' />
   </node>
   <node id='-5009672' action='modify' visible='true' lat='43.43589206171' lon='-80.57976166653'>
-    <tag k='btree' v='standard_driver.btree' />
+    <tag k='btree' v='st_standard_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />

--- a/scenarios/coretest_scenarios/trafficlight_green.gs.osm
+++ b/scenarios/coretest_scenarios/trafficlight_green.gs.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5145297' action='modify' visible='true' lat='43.47822413504' lon='-80.5193980465' />
+  <node id='-5145298' action='modify' visible='true' lat='43.47826194033' lon='-80.51976044018'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_university_weber_alt.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='red to green light scenario' />
+    <tag k='timeout' v='15' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5145299' action='modify' visible='true' lat='43.47800705624' lon='-80.51976589147'>
+    <tag k='gs' v='origin' />
+    <tag k='name' v='origin' />
+  </node>
+  <node id='-5145300' action='modify' visible='true' lat='43.47790730383' lon='-80.52029198388' />
+  <node id='-5145304' action='modify' visible='true' lat='43.47860769581' lon='-80.52572103261' />
+  <node id='-5145306' action='modify' visible='true' lat='43.47823895436' lon='-80.51935405368'>
+    <tag k='btree' v='st_standard_driver.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='crossing_vehicle' />
+    <tag k='route' v='east_west_route' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='155' />
+  </node>
+  <node id='-5145307' action='modify' visible='true' lat='43.47804042874' lon='-80.52000462027'>
+    <tag k='duration' v='3,10,1,7' />
+    <tag k='gs' v='trafficlight' />
+    <tag k='name' v='tl_e_w' />
+    <tag k='states' v='R,G,Y,R' />
+    <tag k='type' v='default' />
+  </node>
+  <way id='-1949945' action='modify' visible='true'>
+    <nd ref='-5145297' />
+    <nd ref='-5145300' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='east_west_route' />
+  </way>
+</osm>

--- a/scenarios/coretest_scenarios/trafficlight_red.gs.osm
+++ b/scenarios/coretest_scenarios/trafficlight_red.gs.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5145331' action='modify' visible='true' lat='43.47822413504' lon='-80.5193980465' />
+  <node id='-5145332' action='modify' visible='true' lat='43.47826194033' lon='-80.51976044018'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_university_weber_alt.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='red to green light scenario' />
+    <tag k='timeout' v='25' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5145333' action='modify' visible='true' lat='43.47800705624' lon='-80.51976589147'>
+    <tag k='gs' v='origin' />
+    <tag k='name' v='origin' />
+  </node>
+  <node id='-5145334' action='modify' visible='true' lat='43.47790730383' lon='-80.52029198388' />
+  <node id='-5145338' action='modify' visible='true' lat='43.47860769581' lon='-80.52572103261' />
+  <node id='-5145340' action='modify' visible='true' lat='43.47823992752' lon='-80.51933527822'>
+    <tag k='btree' v='st_standard_driver.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='red_light_runner' />
+    <tag k='route' v='east_west_route' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='155' />
+  </node>
+  <node id='-5145341' action='modify' visible='true' lat='43.47804042874' lon='-80.52000462027'>
+    <tag k='duration' v='2,0.5,10,10' />
+    <tag k='gs' v='trafficlight' />
+    <tag k='name' v='tl_e_w' />
+    <tag k='states' v='G,Y,R,G' />
+    <tag k='type' v='default' />
+  </node>
+  <way id='-1947925' action='modify' visible='true'>
+    <nd ref='-5145331' />
+    <nd ref='-5145334' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='east_west_route' />
+  </way>
+</osm>

--- a/scenarios/coretest_scenarios/trafficlight_red_follow.gs.osm
+++ b/scenarios/coretest_scenarios/trafficlight_red_follow.gs.osm
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5145401' action='modify' visible='true' lat='43.47822413504' lon='-80.5193980465' />
+  <node id='-5145402' action='modify' visible='true' lat='43.47826194033' lon='-80.51976044018'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_university_weber_alt.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='green to red light scenario while following vehicle that does not stop' />
+    <tag k='timeout' v='30' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5145403' action='modify' visible='true' lat='43.47800705624' lon='-80.51976589147'>
+    <tag k='gs' v='origin' />
+    <tag k='name' v='origin' />
+  </node>
+  <node id='-5145404' action='modify' visible='true' lat='43.47790730383' lon='-80.52029198388' />
+  <node id='-5145405' action='modify' visible='true' lat='43.47860769581' lon='-80.52572103261' />
+  <node id='-5145406' action='modify' visible='true' lat='43.47823992752' lon='-80.51933527822'>
+    <tag k='btree' v='st_standard_driver.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='red_light_follower' />
+    <tag k='route' v='east_west_route' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='155' />
+  </node>
+  <node id='-5145407' action='modify' visible='true' lat='43.47804042874' lon='-80.52000462027'>
+    <tag k='duration' v='2,0.5,10,10' />
+    <tag k='gs' v='trafficlight' />
+    <tag k='name' v='tl_e_w' />
+    <tag k='states' v='G,Y,R,G' />
+    <tag k='type' v='default' />
+  </node>
+  <node id='-5145409' action='modify' visible='true' lat='43.47820088433' lon='-80.51945731312'>
+    <tag k='btree' v='drive.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='red_light_runner' />
+    <tag k='route' v='east_west_route' />
+    <tag k='vid' v='2' />
+    <tag k='yaw' v='155' />
+  </node>
+  <way id='-1947938' action='modify' visible='true'>
+    <nd ref='-5145401' />
+    <nd ref='-5145404' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='east_west_route' />
+  </way>
+</osm>


### PR DESCRIPTION
- Ported traffic light tests to coretest_scenarios
- Fixed tintersection scenario. Standard drivers must use st_standard_driver.btree to perform intersection handling. The basic drive.tree only follows lane.
