### PR TITLE
use LocalCartesianProjector when available (for co-simulation)

### DIFF
--- a/GSServer.py
+++ b/GSServer.py
@@ -13,7 +13,13 @@ from SimConfig import SimConfig
 from dash.Dashboard import *
 from mapping.LaneletMap import *
 from ScenarioSetup import *
-from lanelet2.projection import UtmProjector
+try:
+    from lanelet2.projection import LocalCartesianProjector
+    use_local_cartesian=True
+except ImportError:
+    from lanelet2.projection import UtmProjector
+    use_local_cartesian=False
+
 import glog as log
 
 def start_server(args, m=MVelKeepConfig()):
@@ -99,7 +105,12 @@ def start_server(args, m=MVelKeepConfig()):
     log.info('GeoScenario server shutdown')
 
 def verify_map_file(map_file, lanelet_map:LaneletMap):
-    projector = UtmProjector(lanelet2.io.Origin(43.0, -80))
+    if use_local_cartesian:
+        projector = LocalCartesianProjector(lanelet2.io.Origin(43.4681668322, -80.5436763174, 302))
+        log.info("Using LocalCartesianProjector")
+    else:
+        projector = UtmProjector(lanelet2.io.Origin(43.4681668322, -80.5436763174, 302))
+        log.info("Using UTMProjector")
     lanelet_map.load_lanelet_map(map_file, projector)
 
 

--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -6,7 +6,12 @@
 # --------------------------------------------
 
 from types import LambdaType
-from lanelet2.projection import UtmProjector
+try:
+    from lanelet2.projection import LocalCartesianProjector
+    use_local_cartesian=True
+except ImportError:
+    from lanelet2.projection import UtmProjector
+    use_local_cartesian=False
 from lanelet2.core import GPSPoint
 from mapping.LaneletMap import *
 from SimConfig import SimConfig
@@ -54,8 +59,14 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         map_file = os.path.join(map_path, parser.globalconfig.tags['lanelet']) #use parameter map path
     # use origin from gsc file to project nodes to sim frame
     altitude  = parser.origin.tags['altitude'] if 'altitude' in parser.origin.tags else 0.0
-    projector = UtmProjector(lanelet2.io.Origin(parser.origin.lat, parser.origin.lon, altitude))
     
+    if use_local_cartesian:
+        projector = LocalCartesianProjector(lanelet2.io.Origin(parser.origin.lat, parser.origin.lon, altitude))
+        log.info("Using LocalCartesianProjector")
+    else:
+        projector = UtmProjector(lanelet2.io.Origin(parser.origin.lat, parser.origin.lon, altitude))
+        log.info("Using UTMProjector")
+
     parser.project_nodes(projector,altitude)
     lanelet_map.load_lanelet_map(map_file, projector)
     sim_config.map_name = parser.globalconfig.tags['lanelet']

--- a/mapping/LaneletMap.py
+++ b/mapping/LaneletMap.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-#rqueiroz@gsd.uwaterloo.ca
-#d43sharm@uwaterloo.ca
+# rqueiroz@uwaterloo.ca
+# d43sharm@uwaterloo.ca
+# mantkiew@uwaterloo.ca
 # --------------------------------------------
 # LaneletMap
 # Class to parse a Lanelet 2 map and interface with lanelet2 library
@@ -10,7 +11,6 @@ import lanelet2
 from lanelet2.core import getId, BasicPoint2d, BasicPoint3d, Point3d, Point2d, ConstPoint2d, ConstPoint3d, BoundingBox2d, BoundingBox3d, LineString3d, LineString2d, ConstLineString2d, ConstLineString3d, Lanelet, RegulatoryElement, TrafficLight, AllWayStop, RightOfWay
 from lanelet2.geometry import distance, to2D, boundingBox2d, boundingBox3d,inside, toArcCoordinates, project, length2d, findNearest, intersects2d, intersects3d
 from lanelet2.traffic_rules import Locations, Participants
-from lanelet2.projection import UtmProjector
 from lanelet2.routing import RelationType, Route
 
 from matplotlib import pyplot as plt


### PR DESCRIPTION
otherwise default to UTMProjector.

The WISE ADS stack (Lanelet2 map server) uses the LocalCartesian projector. When GSS uses the standard UTMProjector, everything is shifted. This PR allows using the LocalCartesian whenever available (that is for people who use our fork of Lanelet2 library, which implements it) and for people using WISE ADS and Sim. For others, the standard UTMProjector is used otherwise. 

When you just install the normal `ros-noetic-lanelet2` package in Ubuntu and start the server, you'll see a log message:
```
ScenarioSetup.py:68] Using UTMProjector
```
But when you have our fork of Lanelet2 sourced, you'll see 
```
ScenarioSetup.py:65] Using LocalCartesianProjector
```.

In either case, the scenarios work the same but LocalCartesian better handles elevations and everybody with WISE ADS/Sim will have it for co-simulation.