### PR TITLE
Dependency updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Lanelet2"]
-	path = Lanelet2
-	url = https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Includes: GeoScenario Parser, Checker, Sim Vehicle Planner with Behavior Trees a
 - [py_trees](https://github.com/splintered-reality/py_trees)
 - tk
 - sysv-ipc
-- antlr4-python3-runtime
+- antlr4-python3-runtime==4.9.3 (later versions cause a parsing error `Exception: Could not deserialize ATN with version (expected 4).`)
 - antlr-denter
 
 To automatically install the dependencies, execute

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 #   GeoScenario Server
+
 Includes: GeoScenario Parser, Checker, Sim Vehicle Planner with Behavior Trees and Maneuver Models.
 
 ## Dependencies
+
+- Ubuntu 20.04
 
 ### Apt packages
 
@@ -25,17 +28,16 @@ Includes: GeoScenario Parser, Checker, Sim Vehicle Planner with Behavior Trees a
 - antlr4-python3-runtime
 - antlr-denter
 
-### Source packages
-
-- Lanelet2 (submodule)
-
 To automatically install the dependencies, execute
+
 ```
 bash scripts/install_dependencies.bash
 ```
 
 ## Running
+
 - run `python3.8 GSServer.py -s scenarios/<geoscenario_file>` to start the Server.
+
 ```
 optional arguments:
   -h, --help            show this help message and exit

--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -20,7 +20,7 @@ install_python_dependencies()
     echo ""
     echo "Installing the required dependencies for GeoScenario Server for Python3.8"
     echo ""
-    python3.8 -m pip -q install numpy scipy glog matplotlib py_trees antlr4-python3-runtime tk sysv-ipc antlr-denter
+    python3.8 -m pip -q install numpy scipy glog matplotlib py_trees antlr4-python3-runtime==4.9.3 tk sysv-ipc antlr-denter
 }
 
 install_lanelet2_python38()

--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -20,7 +20,7 @@ install_python_dependencies()
     echo ""
     echo "Installing the required dependencies for GeoScenario Server for Python3.8"
     echo ""
-    python3.8 -m pip -q install numpy scipy glog matplotlib py_trees antlr4-python3-runtime==4.9.3 tk sysv-ipc antlr-denter
+    python3.8 -m pip install numpy scipy glog matplotlib py_trees==0.7.6 antlr4-python3-runtime==4.9.3 tk sysv-ipc antlr-denter
 }
 
 install_lanelet2_python38()

--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -72,7 +72,8 @@ install_lanelet2_binary()
 
 install_python_dependencies
 install_lanelet2_binary
-install_lanelet2_python38
+# No need to install from source anymore as all pull requests with the required fixes have been merged
+# install_lanelet2_python38
 
 echo ""
 echo "Successfully installed GeoScenario Server dependencies."


### PR DESCRIPTION
Some adjustments to keep the software running:

- Remove building Lanelet2 from sources. Not needed anymore as all required PRs have been merged and the new binary was released. Removed the submodule.
- Downgrade  `antlr4-python3-runtime==4.9.3` to fix the parsing error `Could not deserialize ATN with version (expected 4)`
- Downgrade `py-trees==0.7.6` to match version from ROS package `ros-noetic-py-trees`
- Updated README and the script