### PR TITLE
Partial PV support

### DIFF
--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -59,7 +59,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         map_file = os.path.join(map_path, parser.globalconfig.tags['lanelet']) #use parameter map path
     # use origin from gsc file to project nodes to sim frame
     altitude  = parser.origin.tags['altitude'] if 'altitude' in parser.origin.tags else 0.0
-    
+
     if use_local_cartesian:
         projector = LocalCartesianProjector(lanelet2.io.Origin(parser.origin.lat, parser.origin.lon, altitude))
         log.info("Using LocalCartesianProjector")
@@ -97,7 +97,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         sim_traffic.add_vehicle(ego_vehicle)
 
     #========= Vehicles
-    log.info("Scenario Setup: initializing vehicles.")
+    log.info("Scenario Setup, initializing vehicles:")
     for vid, vnode in parser.vehicles.items():
         if len(sim_traffic.vehicles) >= MAX_NVEHICLES:
             break
@@ -117,7 +117,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         yaw = float(vnode.tags['yaw'])*-1 if 'yaw' in vnode.tags else 0.0
         #print(yaw)
         btype = vnode.tags['btype'].lower() if 'btype' in vnode.tags else ''
-        log.info("Vehicle {}, behavior type {}".format(vid,btype))    
+        # log.info("Vehicle {}, behavior type {}".format(vid,btype))
         #SDV Model (dynamic vehicle)
         if btype == 'sdv':
             #start state
@@ -160,11 +160,11 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                 log.error("SDV {} requires a route .".format(vid))
                 continue
             gs_route = vnode.tags['route']
-            route_nodes = [ TrajNode(x = node.x, y = node.y) for node in parser.routes[gs_route].nodes ]   
+            route_nodes = [ TrajNode(x = node.x, y = node.y) for node in parser.routes[gs_route].nodes ]
             route_nodes.insert(0, TrajNode(x=vnode.x,y=vnode.y)) #insert vehicle location as start of route
             #btree
             #a behavior tree file (.btree) inside the btype's folder, defaulted in btrees
-            root_btree_name = vnode.tags['btree'] if 'btree' in vnode.tags else "st_standard_driver.btree" 
+            root_btree_name = vnode.tags['btree'] if 'btree' in vnode.tags else "st_standard_driver.btree"
             try:
                 vehicle = SDV(  vid, name, root_btree_name, start_state, yaw,
                                 lanelet_map, route_nodes,
@@ -184,6 +184,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                     vehicle.btree_reconfig = vnode.tags['btconfig']
                 vehicle.model = model
                 sim_traffic.add_vehicle(vehicle)
+                log.info("Vehicle {} initialized with SDV behavior".format(vid))
             except Exception as e:
                 log.error("Failed to initialize vehicle {}".format(vid))
                 raise e
@@ -208,38 +209,76 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                     trajectory.append(nd)
                 vehicle = TV(vid = vid,                                     #<= must ne integer
                             name = name,                                    #vehicle name
-                            start_state =  start_state,                     #vehicle start state in cartesian frame [x,x_vel,x_acc, y,y_vel,y_acc]
+                            start_state = start_state,                      #vehicle start state in cartesian frame [x,x_vel,x_acc, y,y_vel,y_acc]
                             yaw = yaw,
                             trajectory = trajectory)                        #a valid trajectory with at least x,y,time per node
-                            
+
                 sim_traffic.add_vehicle(vehicle)
+                log.info("Vehicle {} initialized with TV behavior".format(vid))
             except Exception as e:
                 log.error("Failed to initialize vehicle {}".format(vid))
                 raise e
 
         # Path Vehicle (PV)
         elif btype == 'pv':
-            vehicle = Vehicle(vid, name, start_state, yaw=yaw)
+            if 'path' not in vnode.tags:
+                log.error("PV {} requires a path".format(vid))
+                continue
+
+            p_name = vnode.tags['path']
+            p_nodes = parser.paths[p_name].nodes
+            path = []
+            path_length = 0.0
+
+            for i in range(len(p_nodes)):
+            # for node in p_nodes:
+                if (i > 0):
+                    path_length += math.hypot(p_nodes[i].x - p_nodes[i-1].x, p_nodes[i].y - p_nodes[i-1].y)
+                nd = PathNode()
+                nd.x = float(p_nodes[i].x)
+                nd.y = float(p_nodes[i].y)
+                nd.s = path_length
+                # Convert from km/h to m/s
+                nd.speed = float(p_nodes[i].tags['agentspeed'] / 3.6) if ('agentspeed' in p_nodes[i].tags) else None
+                path.append(nd)
+
+
+            # Set initial longitudinal velocity, path always takes precedence
+            frenet_state = [0.0,0.0,0.0, 0.0,0.0,0.0]
+            if path[0].speed is not None:
+                frenet_state[1] = path[0].speed / 3.6
+            elif 'speed' in vnode.tags:
+                frenet_state[1] = float(vnode.tags['speed']) / 3.6
+            else:
+                log.error("PV {} has no initial speed".format(vid))
+                continue
+
+            vehicle = PV(vid, name, start_state=start_state, frenet_state=frenet_state, yaw=yaw, path=path, debug_shdata=sim_traffic.debug_shdata)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
-            log.warning("Path-based vehicles are still not supported in GeoScenario Server {}".format(vid))
+            log.info("Vehicle {} initialized with PV behavior".format(vid))
+            log.warning("Path-based vehicles are only partially supported in GeoScenario Server {}".format(vid))
             continue
 
         # External Vehicle (EV)
         elif btype == 'ev':
             bsource = vnode.tags['bsource']
-            vehicle = EV(vid, name, start_state, yaw, bsource) 
+            vehicle = EV(vid, name, start_state, yaw, bsource)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
+            log.info("Vehicle {} initialized as an external vehicle".format(vid))
 
         # Neutral Vehicle
         else:
             vehicle = Vehicle(vid, name, start_state, yaw=yaw)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
+            log.info("Vehicle {} initialized as a motionless vehicle".format(vid))
         #=========
 
     #========= Pedestrians
+    if len(parser.pedestrians.items()) > 0:
+        log.info("Scenario Setup, initializing pedestrians:")
     for pid, pnode in parser.pedestrians.items():
         pid = int(pid)
         name = pnode.tags['name']
@@ -277,6 +316,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                     trajectory.append(nd)
                 pedestrian = TP(pid, name, start_state, yaw, trajectory)
                 sim_traffic.add_pedestrian(pedestrian)
+                log.info("Pedestrian {} initialized with TP behavior".format(pid))
             except Exception as e:
                 log.error("Failed to initialize pedestrian {}".format(pid))
                 raise e
@@ -310,12 +350,14 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                                 btype=btype)
 
                 sim_traffic.add_pedestrian(pedestrian)
+                log.info("Pedestrian {} initialized with SP behavior".format(pid))
             except Exception as e:
                 log.error("Failed to initialize pedestrian {}".format(pid))
                 raise e
         else:
             pedestrian = Pedestrian(pid, name, start_state, yaw)
             sim_traffic.add_pedestrian(pedestrian)
+            log.info("Pedestrian {} initialized as a motionless pedestrian".format(pid))
 
     #========= Static Objects
     #Area based objetics are not supported yet.

--- a/dash/Dashboard.py
+++ b/dash/Dashboard.py
@@ -410,7 +410,7 @@ class Dashboard(object):
         static_objects = traffic_state.static_objects
         regulatory_elements = traffic_state.regulatory_elements
         goal_point_frenet = traffic_state.goal_point_frenet
-        
+
         #layout
         #plt.rc('axes', axisbelow=True) #plt.axis.set_axisbelow(True) #keep grid below data
         plt.grid(True, zorder=1)
@@ -425,8 +425,10 @@ class Dashboard(object):
         fig.tight_layout(pad=0.05)
 
         #road
-        plt.axhline(lane_config.left_bound, color="k", linestyle='-', zorder=0)
-        plt.axhline(lane_config.right_bound, color="k", linestyle='-', zorder=0)
+        if lane_config.left_bound is not None:
+            plt.axhline(lane_config.left_bound, color="k", linestyle='-', zorder=0)
+        if lane_config.right_bound is not None:
+            plt.axhline(lane_config.right_bound, color="k", linestyle='-', zorder=0)
         plt.title("Frenet Frame. Vehicle {}:".format(center_id))
         plt.xlabel('S')
         plt.ylabel('D')
@@ -436,9 +438,9 @@ class Dashboard(object):
             x, y = lane_config.stopline_pos
             plt.axvline(x, color= 'r', linestyle='-', zorder=1)
 
-        
+
         #road_occupancy
-        if SHOW_OCCUPANCY:
+        if SHOW_OCCUPANCY and traffic_state.road_occupancy is not None:
             road_occupancy:RoadOccupancy = traffic_state.road_occupancy
             cellsize = 1
             size = cellsize*3
@@ -464,14 +466,14 @@ class Dashboard(object):
             plt.gca().add_patch(rect)
             rect = plt.Rectangle( (anchorx,anchory+1),cellsize,cellsize,linewidth=1,zorder=2, edgecolor='k',facecolor = "k" if road_occupancy.back else 'none') #back
             plt.gca().add_patch(rect)
-            
+
             anchorx = anchorx + size + 1
             y_label = "y: " + str(road_occupancy.yielding_zone)
             i_label = "i: " + str(road_occupancy.intersecting_zone)
             gca.text(anchorx, anchory, y_label)
             gca.text(anchorx, anchory + cellsize, i_label)
-        
-        
+
+
             #junction
             #size = 3
             #intersections = traffic_state.intersections
@@ -482,52 +484,56 @@ class Dashboard(object):
             #        intersection.
 
 
-        #re
-        for re in regulatory_elements:
-            if isinstance(re, sv.SDVTrafficState.TrafficLightState):
-                colorcode,_ = self.get_color_by_type('trafficlight',re.color)
-                x, y = re.stop_position
-                plt.axvline(x, color= colorcode, linestyle='-', zorder=1)
-            elif isinstance(re, sv.SDVTrafficState.RightOfWayState):
-                pass
-                #for ll_id in re.row_lanelets:
-                    #colorfillcode = 'r' if re.row_lanelets[ll_id] > 0 else 'g'
-                    #ll = self.lanelet_map.laneletLayer[ll_id]
-            elif isinstance(re, sv.SDVTrafficState.AllWayStopState):
-                pass
+        # Regulatory Elements
+        if (regulatory_elements is not None):
+            for re in regulatory_elements:
+                if isinstance(re, sv.SDVTrafficState.TrafficLightState):
+                    colorcode,_ = self.get_color_by_type('trafficlight',re.color)
+                    x, y = re.stop_position
+                    plt.axvline(x, color= colorcode, linestyle='-', zorder=1)
+                elif isinstance(re, sv.SDVTrafficState.RightOfWayState):
+                    pass
+                    #for ll_id in re.row_lanelets:
+                        #colorfillcode = 'r' if re.row_lanelets[ll_id] > 0 else 'g'
+                        #ll = self.lanelet_map.laneletLayer[ll_id]
+                elif isinstance(re, sv.SDVTrafficState.AllWayStopState):
+                    pass
 
         #other vehicles, from main vehicle POV:
-        for vid,vehicle in vehicles.items():
-            colorcode,alpha = self.get_color_by_type('vehicle',vehicle.type,vehicle.sim_state,vehicle.name)
-            vs = vehicle.state
-            plt.plot( vs.s, vs.d, colorcode+".", zorder=5)
-            circle1 = plt.Circle((vs.s, vs.d), VEHICLE_RADIUS, color=colorcode, fill=False, zorder=5, alpha=alpha)
-            gca.add_artist(circle1)
-            label = label = "ego ({})".format(int(vid)) if vehicle.name.lower() == 'ego' else "v{}".format(int(vid))
-            gca.text(vs.s, vs.d+1.5, label)
+        if vehicles is not None:
+            for vid,vehicle in vehicles.items():
+                colorcode,alpha = self.get_color_by_type('vehicle',vehicle.type,vehicle.sim_state,vehicle.name)
+                vs = vehicle.state
+                plt.plot( vs.s, vs.d, colorcode+".", zorder=5)
+                circle1 = plt.Circle((vs.s, vs.d), VEHICLE_RADIUS, color=colorcode, fill=False, zorder=5, alpha=alpha)
+                gca.add_artist(circle1)
+                label = label = "ego ({})".format(int(vid)) if vehicle.name.lower() == 'ego' else "v{}".format(int(vid))
+                gca.text(vs.s, vs.d+1.5, label)
 
         #pedestrian
-        for pid, pedestrian in pedestrians.items():
-            if pedestrian.sim_state is ActorSimState.INACTIVE:
-                continue
-            colorcode,alpha = self.get_color_by_type('pedestrian',pedestrian.type, pedestrian.sim_state)
-            x = pedestrian.state.s
-            y = pedestrian.state.d
-            #if (x_min <= x <= x_max) and (y_min <= y <= y_max):
-            plt.plot(x, y, colorcode+'.',markersize=1, zorder=10)
-            circle1 = plt.Circle((x, y), Pedestrian.PEDESTRIAN_RADIUS, color=colorcode, fill=False, zorder=10,  alpha=alpha)
-            plt.gca().add_artist(circle1)
-            label = "p{}".format(pid)
-            plt.gca().text(x+1, y+1, label, style='italic', zorder=10)
+        if pedestrians is not None:
+            for pid, pedestrian in pedestrians.items():
+                if pedestrian.sim_state is ActorSimState.INACTIVE:
+                    continue
+                colorcode,alpha = self.get_color_by_type('pedestrian',pedestrian.type, pedestrian.sim_state)
+                x = pedestrian.state.s
+                y = pedestrian.state.d
+                #if (x_min <= x <= x_max) and (y_min <= y <= y_max):
+                plt.plot(x, y, colorcode+'.',markersize=1, zorder=10)
+                circle1 = plt.Circle((x, y), Pedestrian.PEDESTRIAN_RADIUS, color=colorcode, fill=False, zorder=10,  alpha=alpha)
+                plt.gca().add_artist(circle1)
+                label = "p{}".format(pid)
+                plt.gca().text(x+1, y+1, label, style='italic', zorder=10)
 
         #objects
-        for oid, obj in static_objects.items():
-            x = obj.s
-            y = obj.d
-            #if (x_min <= x <= x_max) and (y_min <= y <= y_max):
-            plt.plot(x, y, 'kx',markersize=6, zorder=10)
-            label = "{}".format(oid)
-            plt.gca().text(x+1, y+1, label, style='italic', zorder=10)
+        if static_objects is not None:
+            for oid, obj in static_objects.items():
+                x = obj.s
+                y = obj.d
+                #if (x_min <= x <= x_max) and (y_min <= y <= y_max):
+                plt.plot(x, y, 'kx',markersize=6, zorder=10)
+                label = "{}".format(oid)
+                plt.gca().text(x+1, y+1, label, style='italic', zorder=10)
 
         #main vehicle
         if goal_point_frenet is not None:
@@ -554,7 +560,7 @@ class Dashboard(object):
         # update lane config based on current (possibly outdated) reference frame
         #lane_config = self.read_map(vehicle_state, self.reference_path)
 
-        
+
 
 
     def get_color_by_type(self,actor,a_type,sim_state = None, name = ''):
@@ -569,11 +575,13 @@ class Dashboard(object):
                 colorcode = 'c' #cyan
             elif a_type == Vehicle.TV_TYPE:
                 colorcode = 'k' #black
+            elif a_type == Vehicle.PV_TYPE:
+                colorcode = 'k' #black
         elif actor== 'pedestrian':
             if a_type == Pedestrian.EP_TYPE:
                 colorcode = 'r' #red
             elif a_type == Pedestrian.TP_TYPE:
-                colorcode = 'r' #bred
+                colorcode = 'r' #red
             elif a_type == Pedestrian.PP_TYPE:
                 colorcode = 'r' #red
         elif actor== 'trafficlight':

--- a/scenarios/test_scenarios/gs_straight_drive.osm
+++ b/scenarios/test_scenarios/gs_straight_drive.osm
@@ -9,7 +9,7 @@
     <tag k='version' v='2.0' />
   </node>
   <node id='-2610801' action='modify' visible='true' lat='49.0072437435' lon='8.45708393074'>
-    <tag k='btree' v='st_driveslow.btree' />
+    <tag k='btree' v='st_slow_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />
@@ -28,7 +28,7 @@
   <node id='-2637032' action='modify' visible='true' lat='49.00729972481' lon='8.45710179305' />
   <node id='-2637033' action='modify' visible='true' lat='49.00818215891' lon='8.45824935668' />
   <node id='-2637043' action='modify' visible='true' lat='49.00726589979' lon='8.45704525575'>
-    <tag k='btree' v='st_drivefast.btree' />
+    <tag k='btree' v='st_fast_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />

--- a/scenarios/test_scenarios/gs_straight_drive_frenetstart.osm
+++ b/scenarios/test_scenarios/gs_straight_drive_frenetstart.osm
@@ -11,7 +11,7 @@
   <node id='-2645831' action='modify' visible='true' lat='49.00726025868' lon='8.45718707844' />
   <node id='-2645832' action='modify' visible='true' lat='49.00814281693' lon='8.45832977088' />
   <node id='-2645833' action='modify' visible='true' lat='49.00725737909' lon='8.45710807062'>
-    <tag k='btree' v='st_driveslow.btree' />
+    <tag k='btree' v='st_slow_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />
@@ -27,7 +27,7 @@
     <tag k='gs' v='origin' />
   </node>
   <node id='-2645835' action='modify' visible='true' lat='49.0072419153' lon='8.4571627156'>
-    <tag k='btree' v='st_driveslow.btree' />
+    <tag k='btree' v='st_slow_driver.btree' />
     <tag k='btype' v='SDV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />

--- a/scenarios/test_scenarios/gs_straight_pv.osm
+++ b/scenarios/test_scenarios/gs_straight_pv.osm
@@ -16,24 +16,19 @@
   <node id='-5149179' action='modify' visible='true' lat='49.00729972481' lon='8.45710179305' />
   <node id='-5149180' action='modify' visible='true' lat='49.00818215891' lon='8.45824935668' />
   <node id='-5149181' action='modify' visible='true' lat='49.00726589979' lon='8.45704525575'>
-    <tag k='btree' v='st_fast_driver.btree' />
-    <tag k='btype' v='SDV' />
+    <tag k='btype' v='PV' />
     <tag k='gs' v='vehicle' />
     <tag k='model' v='light_vehicle' />
     <tag k='name' v='v1' />
-    <tag k='route' v='left_route' />
+    <tag k='path' v='straight_path' />
+    <tag k='speed' v='40' />
     <tag k='vid' v='1' />
     <tag k='yaw' v='310' />
-  </node>
-  <node id='-5149184' action='modify' visible='true' lat='49.0081535901' lon='8.45830837123'>
-    <tag k='area' v='no' />
-    <tag k='gs' v='staticobject' />
-    <tag k='name' v='myobject' />
   </node>
   <way id='-1948238' action='modify' visible='true'>
     <nd ref='-5149179' />
     <nd ref='-5149180' />
-    <tag k='gs' v='route' />
-    <tag k='name' v='left_route' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='straight_path' />
   </way>
 </osm>

--- a/scenarios/trees/st_drivefast.btree
+++ b/scenarios/trees/st_drivefast.btree
@@ -1,3 +1,0 @@
-behaviortree st_driveslow:
-    ->
-        subtree drive( m_keepvelocity=MVelKeepConfig(vel=MP(16, 10, 6),max_diff=12.0) )

--- a/scenarios/trees/st_driveslow.btree
+++ b/scenarios/trees/st_driveslow.btree
@@ -1,3 +1,0 @@
-behaviortree st_driveslow:
-    ->
-        subtree drive( m_keepvelocity=MVelKeepConfig(vel=MP(10, 10, 6)) )

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -55,8 +55,8 @@ class SVPlanner(object):
         self._mplan_sharr = Array('f', c)
         #Process based
         self._process = Process(target=self.run_planner_process, args=(
-            self.traffic_state_sharr, 
-            self._mplan_sharr, 
+            self.traffic_state_sharr,
+            self._mplan_sharr,
             self._debug_shdata), daemon=True)
         self._process.start()
 
@@ -85,7 +85,7 @@ class SVPlanner(object):
         # New plan
         self.last_plan = plan
         return plan
-        
+
 
     #==SUB PROCESS=============================================
     def before_exit(self,*args):
@@ -98,12 +98,12 @@ class SVPlanner(object):
         signal(SIGTERM, self.before_exit)
 
         self.sync_planner = TickSync(rate=PLANNER_RATE, realtime=True, block=True, verbose=False, label="PP{}".format(self.vid))
-        
-        
+
+
         #Behavior Layer
         #Note: If an alternative behavior module is to be used, it must be replaced here.
         self.behavior_layer = BehaviorLayer(self.vid, self.root_btree_name, self.btree_reconfig, self.btree_locations, self.btype)
-        
+
         # target time for planning task. Can be fixed or variable up to max planner tick time
         task_label = "V{} plan".format(self.vid)
         if USE_FIXED_PLANNING_TIME:
@@ -124,13 +124,13 @@ class SVPlanner(object):
             else:
                 #vehicle state not available. Vehicle can be inactive.
                 continue
-            
+
             if self.sdv_route is None:
                 self.sdv_route = SDVRoute(
-                    #self.sim_config.lanelet_routes[self.vid], 
+                    #self.sim_config.lanelet_routes[self.vid],
                     self.laneletmap,
-                    vehicle_state.x, vehicle_state.y, 
-                    self.route_nodes, 
+                    vehicle_state.x, vehicle_state.y,
+                    self.route_nodes,
                     #self.sim_config.goal_points[self.vid]
                 )
 
@@ -140,10 +140,10 @@ class SVPlanner(object):
             if not traffic_state:
                 log.warn("Invalid planner state, skipping planning step...")
                 continue
-            
+
             #BTree Tick - using frenet state and lane config based on old ref path
             mconfig, ref_path_changed, snapshot_tree = self.behavior_layer.tick(traffic_state)
-            
+
             # when ref path changes, must recalculate the path, lane config and relative state of other vehicles
             if ref_path_changed:
                 log.info("PATH CHANGED")
@@ -156,7 +156,7 @@ class SVPlanner(object):
                     log.warn("Invalid planner state, skipping planning step...")
                     continue
                 mconfig, _, snapshot_tree = self.behavior_layer.tick(traffic_state)
-            
+
             # new maneuver
             if self.mconfig and self.mconfig.mkey != mconfig.mkey:
                 log.info("VID {} started maneuver {}".format(self.vid, mconfig.mkey.name))
@@ -216,7 +216,7 @@ class SVPlanner(object):
                         self.last_plan = plan
             else:
                 frenet_traj, cand = None, None
-            
+
             #Debug info (for Dahsboard and Log)
             if self.sim_config.show_dashboard:
                 # change ref path format for pickling (maybe always keep it like this?)
@@ -225,7 +225,7 @@ class SVPlanner(object):
                 if (self.last_plan is not None) and (frenet_traj is None):
                     # shift the trajectories to the old frenet frame they are positioned in
                     traj_s_shift = self.last_plan.ref_path_origin - self.sdv_route.get_reference_path_origin()
-                
+
                 #For pickling
                 traffic_state.intersections = [ intersection.to_primitives() for intersection in traffic_state.intersections]
 
@@ -240,7 +240,7 @@ class SVPlanner(object):
                 )
         log.info('PLANNER PROCESS END. Vehicle{}'.format(self.vid))
 
-    def write_motion_plan(self, mplan_sharr, plan:MotionPlan): 
+    def write_motion_plan(self, mplan_sharr, plan:MotionPlan):
         if not plan:
             return
         #write motion plan
@@ -249,4 +249,4 @@ class SVPlanner(object):
         #print('Writting Sh Data VP')
         #print(mplan_sharr)
         mplan_sharr.release() #<=========RELEASE
-        
+

--- a/sv/SDVTrafficState.py
+++ b/sv/SDVTrafficState.py
@@ -35,11 +35,11 @@ class AllWayStopIntersection:
     stop_position: tuple = None                             #my long stop position in frenet frame
     my_stop_line:ConstLineString2d =  None                  #lanelet stop line (ConstLineString2D)
     yield_lanelets:List = field(default_factory=list)                              #[ll,sl] List with Lanelets and stoplines [ll,sl]
-    #stop_lines:List =  field(default_factory=list)  
+    #stop_lines:List =  field(default_factory=list)
     intersecting_lanelets:List = field(default_factory=list)                       #[ll,s] List with lanelets and place along S of the intersection
     appr_intersecting_lanelets:List = field(default_factory=list)                  #[] List of lanelets approaching intersection
 
-    def to_primitives(self): 
+    def to_primitives(self):
         #Creates a copy replacing Lanelet objects to IDs for pickling (for Debug)
         my_copy = copy(self)
         my_copy.my_stop_line = 0
@@ -53,12 +53,12 @@ class RightOfWayIntersection:
     stop_position:tuple = None                              #my long stop position in frenet frame
     my_stop_line:ConstLineString2d =  None                  #lanelet stop line (ConstLineString2D)
     yield_lanelets:List =  field(default_factory=list)                             #[ll,sl] List with Lanelets and stoplines
-    #stop_lines:List =  field(default_factory=list)  
+    #stop_lines:List =  field(default_factory=list)
     intersecting_lanelets:List = field(default_factory=list)                       #[ll,s] List with lanelets and place along S of the intersection
     appr_intersecting_lanelets:List = field(default_factory=list)                  #[] List of lanelets approaching intersection
     row_lanelets:List = field(default_factory=list)                                #[] List of lanelets with right of way
 
-    def to_primitives(self): 
+    def to_primitives(self):
         #Creates a copy replacing Lanelet objects to IDs for pickling (for Debug)
         my_copy = copy(self)
         my_copy.my_stop_line = 0
@@ -76,7 +76,7 @@ class TrafficLightIntersection:
     intersecting_lanelets:List = field(default_factory=list) #[ll,s] List with lanelets and place along S of the intersection
     color:TrafficLightState = None
 
-    def to_primitives(self): 
+    def to_primitives(self):
         #Creates a copy replacing Lanelet objects to IDs for pickling (for Debug)
         my_copy = copy(self)
         my_copy.my_stop_line = 0
@@ -90,7 +90,7 @@ class PedestrianIntersection:
     my_stop_line:ConstLineString2d =  None                  #lanelet stop line (ConstLineString2D)
     intersecting_lanelets:List = field(default_factory=list)                       #[ll,s] List with lanelets and place along S of the intersection
 
-    def to_primitives(self): 
+    def to_primitives(self):
         #Creates a copy replacing Lanelet objects to IDs for pickling (for Debug)
         my_copy = copy(self)
         my_copy.my_stop_line = 0
@@ -103,7 +103,7 @@ class PedestrianIntersection:
 class RoadOccupancy:
     front:int = None            #Zone 1: same lane, closest vehicle ahead, up to 50m
     left_front:int = None       #Zone 2: lateral, ahead (gap > 0), closest vehicle
-    left:int = None             #Zone 3: lateral, gap == 0, 
+    left:int = None             #Zone 3: lateral, gap == 0,
     left_back:int = None        #Zone 4: lateral, behind (gap < 0), closest vehicle
     back:int = None             #Zone 5: same lane, closest vehicle behind, up to 50m
     right_back:int = None       #Zone 6
@@ -126,8 +126,8 @@ class TrafficState:
     lane_config: LaneConfig
     traffic_vehicles: Dict
     traffic_vehicles_orp: Dict                  #vehicles outside of Reference Path, can't be transformed to current Frenet Frame
-    pedestrians: List
-    static_objects: List
+    pedestrians: List = None
+    static_objects: List = None
     road_occupancy:RoadOccupancy = None
     #road zone
     regulatory_elements: List = None
@@ -146,14 +146,14 @@ def project_dynamic_objects(
     traffic_pedestrians:dict,
     state_time:float,
     expected_planner_time:float):
-    '''Project dynamic objects based on expected planning time (if > 0) 
+    '''Project dynamic objects based on expected planning time (if > 0)
     and their current state"
     '''
 
     if last_plan and expected_planner_time > 0:
         sim_time_ahead = state_time + expected_planner_time
         delta_time = sim_time_ahead - last_plan.start_time
-        if (delta_time > last_plan.trajectory.T): 
+        if (delta_time > last_plan.trajectory.T):
             delta_time = last_plan.trajectory.T
         new_state = last_plan.trajectory.get_state_at(delta_time)
         vehicle_state.set_S(new_state[:3])
@@ -241,7 +241,7 @@ def get_traffic_state(
         except OutsideRefPathException:
             traffic_vehicles_orp[vid] = traffic_vehicles[vid]
             del traffic_vehicles[vid]
-    
+
     for pid, pedestrian in list(traffic_pedestrians.items()):
         try:
             s_vector, d_vector = sim_to_frenet_frame(
@@ -252,7 +252,7 @@ def get_traffic_state(
             pedestrian.state.set_D(d_vector)
         except OutsideRefPathException:
             del traffic_pedestrians[pid]
-    
+
     for soid, so in list(static_objects.items()):
         try:
             so.s, so.d = sim_to_frenet_position(
@@ -292,7 +292,7 @@ def get_traffic_state(
 
 def fill_occupancy(my_vid: int, vehicle_state:VehicleState,lane_config:LaneConfig,traffic_vehicles,traffic_vehicles_orp,lanelet_map:LaneletMap, intersections):
     '''
-        Identify vehicles in strategic zones using the (Frénet Frame) and assign their id. 
+        Identify vehicles in strategic zones using the (Frénet Frame) and assign their id.
         Road Occupancy contains only one vehicle per zone (closest to SDV)
     '''
     half_length = VEHICLE_LENGTH/2
@@ -334,19 +334,19 @@ def fill_occupancy(my_vid: int, vehicle_state:VehicleState,lane_config:LaneConfi
                             right_back.append(vehicle)
                         else:
                             right.append(vehicle)
-                
+
     occupancy = RoadOccupancy()
     occupancy.front = min(front, key=lambda v: v.state.s).id if len(front) > 0 else None
     occupancy.back = max(back, key=lambda v: v.state.s).id if len(back) > 0 else None
-    
+
     occupancy.left = min(left, key=lambda v: v.state.d).id if len(left) > 0 else None
     occupancy.left_back = max(left_back, key=lambda v: v.state.s).id if len(left_back) > 0 else None
     occupancy.left_front = min(left_front, key=lambda v: v.state.s).id if len(left_front) > 0 else None
-    
+
     occupancy.right = max(right, key=lambda v: v.state.d).id if len(right) > 0 else None
     occupancy.right_back = max(right_back, key=lambda v: v.state.s).id if len(right_back) > 0 else None
     occupancy.right_front = min(right_front, key=lambda v: v.state.s).id if len(right_front) > 0 else None
-    
+
     # vehicle and lanelets mapping [vehicle, [ll1,ll2]]
     vehicle_lanelet_map = {}
     for vid,vehicle in traffic_vehicles.items():
@@ -357,11 +357,11 @@ def fill_occupancy(my_vid: int, vehicle_state:VehicleState,lane_config:LaneConfi
         lls = lanelet_map.get_all_occupying_lanelets(vehicle.state.x, vehicle.state.y)
         if lls is not None:
             vehicle_lanelet_map[vehicle] = lls
-    
+
     #print("Vehicle lanelet map")
     #for vehicle,vlls in vehicle_lanelet_map.items():
     #    print (vehicle.id)
-    
+
     def lanelet_overlap(a_list, b_list):
         for a in a_list:
             for b in b_list:
@@ -377,28 +377,28 @@ def fill_occupancy(my_vid: int, vehicle_state:VehicleState,lane_config:LaneConfi
             for vehicle,vlls in vehicle_lanelet_map.items():
                 if lanelet_overlap( vlls, [ inter_ll[0] for inter_ll in intersection.intersecting_lanelets]):
                     occupancy.intersecting_zone.append(vehicle.id)
-            
+
             for vehicle,vlls in vehicle_lanelet_map.items():
                 if lanelet_overlap( vlls, [ inter_ll for inter_ll in intersection.row_lanelets]):
                     occupancy.row_zone.append(vehicle.id)
-            
+
             for yll, stop_line in intersection.yield_lanelets: #list of tuples
                 for vehicle,vlls in vehicle_lanelet_map.items():
                     for vll in vlls:
                         if vll.id == yll.id: #vehicle lanelet in the yielding lanelet set
                             dist = distance(BasicPoint2d(vehicle.state.x,  vehicle.state.y),to2D(stop_line))
-                            if dist < 3: 
+                            if dist < 3:
                                 #print("{} close to stop line, vehicle is in yielding area {}".format(vehicle.id,dist))
                                 occupancy.yielding_zone.append(vehicle.id)
                             else:
                                 #vehicle is still approaching yielding zone
                                 occupancy.appr_yielding_zone.append(vehicle.id)
-            
+
         if isinstance(intersection, AllWayStopIntersection):
 
             for vehicle,vlls in vehicle_lanelet_map.items():
                 if lanelet_overlap( vlls, [ inter_ll[0] for inter_ll in intersection.intersecting_lanelets]):
-                    occupancy.intersecting_zone.append(vehicle.id)      
+                    occupancy.intersecting_zone.append(vehicle.id)
 
             #for cll, s_pos in intersection.intersecting_lanelets:
             #    for vehicle,vlls in vehicle_lanelet_map.items():
@@ -414,18 +414,18 @@ def fill_occupancy(my_vid: int, vehicle_state:VehicleState,lane_config:LaneConfi
                     for vll in vlls:
                         if vll.id == yll.id: #vehicle lanelet in the yielding lanelet set
                             dist = distance(BasicPoint2d(vehicle.state.x,  vehicle.state.y),to2D(stop_line))
-                            if dist < 3: 
+                            if dist < 3:
                                 #print("{} close to stop line, vehicle is in yielding area {}".format(vehicle.id,dist))
                                 occupancy.yielding_zone.append(vehicle.id)
                             else:
                                 #vehicle is still approaching yielding zone
                                 occupancy.appr_yielding_zone.append(vehicle.id)
-        
+
         if isinstance(intersection, TrafficLightIntersection):
             continue
         if isinstance(intersection, PedestrianIntersection):
             continue
-        
+
         #DEBUG:
         #print("Vehicle {} Lanelet Map".format(my_vid))
         #for v,lls in vehicle_lanelet_map.items():
@@ -456,7 +456,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
     # LaneConfig(id, velocity, leftbound, rightbound).
     # /2 to center it on its centerline
     middle_lane_config = LaneConfig(0, 30, middle_lane_width / 2, middle_lane_width / -2)
-    
+
     left_ll, relationship = lanelet_map.get_left(cur_ll)
     if left_ll:
         upper_lane_width = LaneletMap.get_lane_width(left_ll, vehicle_state.x, vehicle_state.y)
@@ -477,7 +477,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
         conflicting_next.extend( lanelet_map.get_conflicting_by_route(sdv_route._lanelet_route,next_ll) )
     #lanelets approaching a conflicting lanelet
     appr_conflicting_next = []
-    for conf_ll in conflicting_next:     
+    for conf_ll in conflicting_next:
         appr_conflicting_next.extend( lanelet_map.get_previous_by_route(sdv_route._lanelet_route, conf_ll) )
 
     # Regulatory Elements
@@ -492,7 +492,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
     intersections = []      #GeoScenario and LL objects
     reg_elem_states = []    #simple data types for pickling
     for re in reg_elems:
-    
+
         # === TRAFFIC LIGHT ===
         if isinstance(re, lanelet2.core.TrafficLight):
             # lanelet2 traffic lights must have a corresponding state from the main process
@@ -513,7 +513,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
                                 color = traffic_light_states[re.id]
                                 )
             intersections.append(intersection)
-        
+
         # === RIGHT OF WAY ===
         elif isinstance(re, lanelet2.core.RightOfWay):
             #Maneuvers: ("Yield", ManeuverType::Yield) ("RightOfWay", ManeuverType::RightOfWay) ("Unknown", ManeuverType::Unknown)
@@ -525,7 +525,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
                 #traffic_signs = re.trafficSigns() # not available on RoW
                 #stop_line = re.stopLine #can be used only when one ref_line exists (one yielding lanelet)
                 my_stop_line = lanelet_map.get_my_ref_line( cur_ll, yield_lanelets, stop_lines )
-                
+
                 #Could be a stop line from a following lanelet
                 if my_stop_line is None and re_added_count > 0:
                     for next_ll in next_lanelets_sequence:
@@ -544,7 +544,7 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
                 #        row_lanelets.append(ll)
                 #reg_elem_states.append( RightOfWayState(stop_position=stop_pos, row_lanelets= []))
                 intersection = RightOfWayIntersection(
-                                    stop_position=stop_pos, 
+                                    stop_position=stop_pos,
                                     my_stop_line = my_stop_line,
                                     yield_lanelets = list(zip(yield_lanelets, stop_lines)),
                                     intersecting_lanelets = list(zip(conflicting_next, itertools.repeat(0))), #TODO, get s position
@@ -579,21 +579,21 @@ def read_map(my_vid:int, lanelet_map:LaneletMap, sdv_route:SDVRoute, vehicle_sta
             middle_lane_config.stopline_pos = stop_pos
             #reg_elem_states.append(AllWayStopState( stop_position=stop_pos ))
             intersection = AllWayStopIntersection(
-                                stop_position=stop_pos, 
+                                stop_position=stop_pos,
                                 my_stop_line = my_stop_line,
                                 yield_lanelets = list(zip(yield_lanelets, stop_lines)),
                                 intersecting_lanelets = list(zip(conflicting_next, itertools.repeat(0))), #TODO, get s position
                                 appr_intersecting_lanelets = appr_conflicting_next
                                 )
             intersections.append(intersection)
-              
+
         # === PEDESTRIAN CROSS ===
         #TODO
 
     return middle_lane_config, intersections, reg_elem_states
 
 def get_closest_point_to_line_on_route(sdv_route,x,y,x2,y2):
-    ''' Find closest point from a cartesian 2D line 
+    ''' Find closest point from a cartesian 2D line
         in current frenet (used for stop lines)
     '''
     try:
@@ -658,8 +658,8 @@ def get_closest_point_to_line_on_route(sdv_route,x,y,x2,y2):
                     #            count = count+1
                     #        int_lanelets[ll.id] = count
                     #        log.warning("row ll {} conflict with my next ll {}".format( row_ll.attributes['name'], next_lls[0].attributes['name']) )
-                
-                #reg_elem_states.append(AllWayStopState(stop_position=stop_pos, 
+
+                #reg_elem_states.append(AllWayStopState(stop_position=stop_pos,
                                                         #yield_lanelets=aws_lanelets,#for pickling
                                                         #intersecting_lanelets=int_lanelets))
     #OTHER CROSSING LANELETS:
@@ -684,7 +684,7 @@ def get_closest_point_to_line_on_route(sdv_route,x,y,x2,y2):
     #                 #    for v_ll_id in v_lanelet_ids:
     #                 #        if v_ll_id == cll.id:
     #                 #            int_lanelets[cll.id] = 1
-        
+
     #             print(int_lanelets)
 
 
@@ -692,6 +692,6 @@ def get_closest_point_to_line_on_route(sdv_route,x,y,x2,y2):
     #returns the closest point from a lanelet in current frenet (conflicting lanelets)
     #distance(cur_ll.centerline, ll.centerline)
     #for p in ll.centerline:
-    #    p.x 
+    #    p.x
     #sim_to_frenet_position(sdv_route.get_reference_path(),x,y,sdv_route.get_reference_path_s_start())
  #   pass

--- a/sv/Vehicle.py
+++ b/sv/Vehicle.py
@@ -34,6 +34,7 @@ class Vehicle(Actor):
     SDV_TYPE = 1
     EV_TYPE = 2
     TV_TYPE = 3
+    PV_TYPE = 4
 
     def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0):
         super().__init__(id, name, start_state, frenet_state, yaw, VehicleState())
@@ -218,7 +219,7 @@ class SDV(Vehicle):
                     heading_unreal *=1
             self.state.yaw = math.degrees(math.atan2(heading[1], heading[0]))
             self.state.yaw_unreal = math.degrees(math.atan2(heading_unreal[1], heading_unreal[0]))
-            
+
             #DEBUG:
             #Note: use this log to evaluate if the "jump back" issue returns
             #log.info("===VID: %d, Plan Tick: %d, Timestamp: %f, Delta Time: %f, Diff: %f, Start Time: %f, S Coef: (%f, %f, %f, %f, %f, %f)===" % (
@@ -253,9 +254,6 @@ class SDV(Vehicle):
             self.next_motion_plan = None
         else:
             self.next_motion_plan = plan
-
-
-
 
 
 class EV(Vehicle):
@@ -325,7 +323,7 @@ class EV(Vehicle):
 class TV(Vehicle):
     """
     A trajectory following vehicle.
-    @param keep_active: If True, pedestrian stays in simulation even when is not following a trajectory
+    @param keep_active: If True, vehicle stays in simulation even when is not following a trajectory
     """
     def __init__(self, vid, name, start_state, yaw, trajectory, keep_active = True):
         super().__init__(vid, name, start_state, yaw=yaw)
@@ -341,3 +339,51 @@ class TV(Vehicle):
     def tick(self, tick_count, delta_time, sim_time):
         Vehicle.tick(self, tick_count, delta_time, sim_time)
         self.follow_trajectory(sim_time, self.trajectory)
+
+
+class PV(Vehicle):
+    """
+    A path following vehicle.
+    @param keep_active: If True, vehicle stays in simulation even when is not following a trajectory
+
+    Not yet supported:
+    Vehicle parameters:
+    - cycles
+    - usespeedprofile
+    Path parameters:
+    - agentacceleration
+    - timetoacceleration
+    """
+    def __init__(self, vid, name, start_state, frenet_state, yaw, path, debug_shdata, keep_active = True):
+        super().__init__(vid, name, start_state, frenet_state, yaw=yaw)
+        self.type = Vehicle.TV_TYPE
+        self.path = path
+        self._debug_shdata = debug_shdata
+        self.keep_active = keep_active
+
+        self.current_path_node = 0
+
+
+    def tick(self, tick_count, delta_time, sim_time):
+        Vehicle.tick(self, tick_count, delta_time, sim_time)
+        self.follow_path(delta_time, sim_time, self.path)
+
+        # Fill in some applicable debug data
+        traffic_state = TrafficState(
+            vid = self.id,
+            sim_time = sim_time,
+            vehicle_state = self.state,
+            lane_config = LaneConfig(left_bound=None, right_bound=None),
+            traffic_vehicles = {},
+            traffic_vehicles_orp = {},
+        )
+        vehicle_path = [(n.x, n.y) for n in self.path]
+        self.sim_traffic.debug_shdata[int(self.id)] = (
+            traffic_state,
+            None,
+            vehicle_path,
+            None,
+            None,
+            None,
+            0
+        )


### PR DESCRIPTION
This PR resolves #112  by adding partial support for Path Vehicles.
By "partial support" I mean everything in the official [geoscenario spec](https://geoscenario2.readthedocs.io/en/latest/vehicles/) is implemented except for:
- `agentacceleration` and `timetoacceleration` tags for path nodes.
- `cycles` and `usespeedprofile` tags for vehicles. I don't think the existing TV implementation supported these vehicle tags either.

This PR contains the following changes:
- Add a new `PV` class of type `Vehicle`
- Update the `Actor` class to include a new `follow_path` function similar to the existing `follow_trajectory` function
- The new follow_path function uses the frenet distance `s` to travel along the defined path, which also allows the PV to provide some data in frenet frame as well
- Updates the dashboard to be able to display frenet frame information without the rest of the debug data
- Adds a brief scenario for testing PVs
- Cleans up some broken btree references and deletes some old duplicated btrees