### PR TITLE
Fix trajectory vehicle

### DIFF
--- a/Actor.py
+++ b/Actor.py
@@ -97,7 +97,7 @@ class Actor(object):
                 for i in range(len(trajectory)-1):
                     n1 = trajectory[i]
                     n2 = trajectory[i+1]
-                    if (n1.time <= sim_time <= n2.time):
+                    if (n1.time <= sim_time < n2.time): # n2 must be strictly after n1
                         dx = n2.x - n1.x
                         dx_vel = n2.x_vel - n1.x_vel
                         dy = n2.y - n1.y
@@ -183,8 +183,8 @@ class Actor(object):
 class TrajNode:
     x:float = 0.0
     y:float = 0.0
-    x_vel:float = 0.0  # calculated as dx/dt
-    y_vel:float = 0.0  # calculated as dy/dt
+    x_vel:float = None  # calculated as dx/dt, the first node same as the second
+    y_vel:float = None  # calculated as dy/dt, the first node same as the second
     time:float = 0.0
     yaw:float = 0.0
 

--- a/Actor.py
+++ b/Actor.py
@@ -98,21 +98,18 @@ class Actor(object):
                     n1 = trajectory[i]
                     n2 = trajectory[i+1]
                     if (n1.time <= sim_time <= n2.time):
-                        # Interpolate
-                        pdiff = (sim_time - n1.time)/(n2.time - n1.time) #always positive
                         dx = n2.x - n1.x
+                        dx_vel = n2.x_vel - n1.x_vel
                         dy = n2.y - n1.y
-                        d = math.hypot(dx, dy)
-
-                        # Position
-                        self.state.x = n1.x + ((n2.x - n1.x) * pdiff)
-                        self.state.y = n1.y + ((n2.y - n1.y) * pdiff)
-
-                        # Velocity
-                        speed = n1.speed + ((n2.speed - n1.speed) * pdiff)
-                        self.state.x_vel = speed * dx/d
-                        self.state.y_vel = speed * dy/d
-
+                        dy_vel = n2.y_vel - n1.y_vel
+                        dt = n2.time - n1.time
+                        x_acc = dx_vel/dt
+                        y_acc = dy_vel/dt
+                        pdiff = (sim_time - n1.time)/dt #always positive
+                        # Interpolate
+                        self.state.set_X([n1.x + (dx * pdiff), n2.x_vel, x_acc])
+                        self.state.set_Y([n1.y + (dy * pdiff), n2.y_vel, y_acc])
+                        self.state.yaw = n1.yaw
                         break
 
             #After trajectory, stay in last position or get removed
@@ -186,8 +183,9 @@ class Actor(object):
 class TrajNode:
     x:float = 0.0
     y:float = 0.0
+    x_vel:float = 0.0  # calculated as dx/dt
+    y_vel:float = 0.0  # calculated as dy/dt
     time:float = 0.0
-    speed:float = 0.0
     yaw:float = 0.0
 
 @dataclass

--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -206,8 +206,13 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                     nd.y = float(node.y)
                     nd.time = float(node.tags['time'])
                     if prev_node is not None:
-                        nd.x_vel = (nd.x - prev_node.x) / (nd.time - prev_node.time)
-                        nd.y_vel = (nd.y - prev_node.y) / (nd.time - prev_node.time)
+                        dt = nd.time - prev_node.time
+                        nd.x_vel = (nd.x - prev_node.x) / dt
+                        nd.y_vel = (nd.y - prev_node.y) / dt
+                        # the first node has unknown velocity, assume the same as the second node's
+                        if prev_node.x_vel is None or prev_node.y_vel is None:
+                            prev_node.x_vel = nd.x_vel
+                            prev_node.y_vel = nd.y_vel
                     nd.yaw = float(node.tags['yaw']) if ('yaw' in node.tags) else None
                     trajectory.append(nd)
                     prev_node = nd

--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -199,14 +199,18 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                 t_name = vnode.tags['trajectory']
                 t_nodes = parser.trajectories[t_name].nodes
                 trajectory = []
+                prev_node = None
                 for node in t_nodes:
                     nd = TrajNode()
                     nd.x = float(node.x)
                     nd.y = float(node.y)
                     nd.time = float(node.tags['time'])
-                    nd.speed = float(node.tags['speed']) if ('speed' in node.tags) else None
+                    if prev_node is not None:
+                        nd.x_vel = (nd.x - prev_node.x) / (nd.time - prev_node.time)
+                        nd.y_vel = (nd.y - prev_node.y) / (nd.time - prev_node.time)
                     nd.yaw = float(node.tags['yaw']) if ('yaw' in node.tags) else None
                     trajectory.append(nd)
+                    prev_node = nd
                 vehicle = TV(vid = vid,                                     #<= must ne integer
                             name = name,                                    #vehicle name
                             start_state = start_state,                      #vehicle start state in cartesian frame [x,x_vel,x_acc, y,y_vel,y_acc]

--- a/sv/Vehicle.py
+++ b/sv/Vehicle.py
@@ -327,7 +327,7 @@ class TV(Vehicle):
             #starts as inactive until trajectory begins
             self.sim_state = ActorSimState.INACTIVE
             self.state.set_X([9999, 0, 0])
-            self.state.set_Y([9999,0,0])
+            self.state.set_Y([9999, 0, 0])
 
     def tick(self, tick_count, delta_time, sim_time):
         Vehicle.tick(self, tick_count, delta_time, sim_time)
@@ -349,7 +349,7 @@ class PV(Vehicle):
     """
     def __init__(self, vid, name, start_state, frenet_state, yaw, path, debug_shdata, keep_active = True):
         super().__init__(vid, name, start_state, frenet_state, yaw=yaw)
-        self.type = Vehicle.TV_TYPE
+        self.type = Vehicle.PV_TYPE
         self.path = path
         self._debug_shdata = debug_shdata
         self.keep_active = keep_active


### PR DESCRIPTION
Trajectory vehicle was broken by recent AStuff merge.
This fixes and improves TV.

* calculate x_vel and y_vel
* calculate x_acc and y_acc
* set yaw from TrajNode (if not set in the scenario, will simply stay as 0.0)

Instead of assuming 0.0 for the x_vel and y_vel of the first node in the trajectory, use the values from the second node.