### PR TITLE
add cmd line args --wait-for-input and --wait-for-client

### DIFF
--- a/GSServer.py
+++ b/GSServer.py
@@ -37,14 +37,21 @@ def start_server(args, m=MVelKeepConfig()):
         btree_locations = [base_btree_location]
     log.info ("Btree search locations set (in order) as: " + str(btree_locations))
 
-    traffic = SimTraffic(lanelet_map, sim_config)
-
     if args.verify_map != "":
         verify_map_file(args.verify_map, lanelet_map)
         return
 
     if args.no_dash:
         sim_config.show_dashboard = False
+
+    if args.wait_for_input:
+        sim_config.wait_for_input = True
+
+    if args.wait_for_client:
+        sim_config.wait_for_client = True
+
+    # use sim_config after all modifications
+    traffic = SimTraffic(lanelet_map, sim_config)
 
     # SCENARIO SETUP
     if args.gsfiles:
@@ -67,6 +74,9 @@ def start_server(args, m=MVelKeepConfig()):
     sync_global = TickSync(rate=sim_config.traffic_rate, realtime=True, block=True, verbose=False, label="EX")
     sync_global.set_timeout(sim_config.timeout)
 
+    if sim_config.wait_for_input:
+        input("Press [ENTER] to start...")
+
     #SIM EXECUTION START
     log.info('SIMULATION START')
     traffic.start()
@@ -77,9 +87,6 @@ def start_server(args, m=MVelKeepConfig()):
         dashboard.start()
     else:
         log.warn("Dashboard will not start")
-
-    if WAIT_FOR_INPUT:
-        input("waiting for [ENTER]...")
 
     while sync_global.tick():
         if sim_config.show_dashboard and not dashboard._process.is_alive(): # might/might not be wanted
@@ -120,9 +127,11 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--scenario", dest="gsfiles", nargs='*', metavar="FILE", default="", help="GeoScenario file. If no file is provided, the GSServer will load a scenario from code")
     parser.add_argument("--verify_map", dest="verify_map", metavar="FILE", default="", help="Lanelet map file")
     parser.add_argument("-q", "--quiet", dest="verbose", default=True, help="don't print messages to stdout")
-    parser.add_argument("-n", "--no_dash", dest="no_dash", action="store_true", help="run without the dashboard")
+    parser.add_argument("-n", "--no-dash", dest="no_dash", action="store_true", help="run without the dashboard")
     parser.add_argument("-m", "--map-path", dest="map_path", default="", help="Set the prefix to append to the value of the attribute `globalconfig->lanelet`")
     parser.add_argument("-b", "--btree-locations", dest="btree_locations", default="", help="Add higher priority locations to search for btrees by agent btypes")
+    parser.add_argument("-wi", "--wait-for-input", dest="wait_for_input", action="store_true", help="Wait for the user to press [ENTER] to start the simulation")
+    parser.add_argument("-wc", "--wait-for-client", dest="wait_for_client", action="store_true", help="Wait for a valid client state to start the simulation")
 
     args = parser.parse_args()
     start_server(args)

--- a/README.md
+++ b/README.md
@@ -49,18 +49,24 @@ bash scripts/setup_conda-forge_env.bash
 - run `python3 GSServer.py -s scenarios/<geoscenario_file>` to start the Server.
 
 ```
-optional arguments:
+usage: GSServer.py [-h] [-s [FILE ...]] [--verify_map FILE] [-q VERBOSE] [-n] [-m MAP_PATH] [-b BTREE_LOCATIONS] [-wi] [-wc]
+
+options:
   -h, --help            show this help message and exit
-  -s [FILE [FILE ...]], --scenario [FILE [FILE ...]]
+  -s [FILE ...], --scenario [FILE ...]
                         GeoScenario file. If no file is provided, the GSServer will load a scenario from code
+  --verify_map FILE     Lanelet map file
   -q VERBOSE, --quiet VERBOSE
                         don't print messages to stdout
-  -m, --map-path
+  -n, --no-dash         run without the dashboard
+  -m MAP_PATH, --map-path MAP_PATH
                         Set the prefix to append to the value of the attribute `globalconfig->lanelet`
-                        e.g. --map-path $HOME/anm_unreal_test_suite/maps
-  -b, --btree-locations
+  -b BTREE_LOCATIONS, --btree-locations BTREE_LOCATIONS
                         Add higher priority locations to search for btrees by agent btypes
-                        e.g. --btree-locations $HOME/anm_unreal_test_suite/btrees
+  -wi, --wait-for-input
+                        Wait for the user to press [ENTER] to start the simulation
+  -wc, --wait-for-client
+                        Wait for a valid client state to start the simulation
 ```
 
 - GeoScenario files (2.0 required) must be placed inside *scenarios/*

--- a/SimConfig.py
+++ b/SimConfig.py
@@ -59,11 +59,11 @@ VEHICLE_LENGTH = 4.5        #vehicle length in [m]
 VEHICLE_WIDTH = 1.8         #vehicle width in [m]
 
 #Planning
-PLANNER_RATE = 3                    #Planner tick rate
-PLANNING_TIME = 0.33                #[s] Must be <= 1/PLANNTER_RATE (we recommend 0.100 for scenarios with <4 vehicles)
-USE_FIXED_PLANNING_TIME = True      #True: the plan will target PLANNING_TIME. False, the planner will vary between PLANNING_TIME and max time (1/PLANNTER_RATE)
-POINTS_PER_METER = 3.0               #The number of points per meter to be used along the vehicle's reference path
-                                     #Note that the value that is used may be slightly different
+PLANNER_RATE = 5                 #Planner tick rate
+PLANNING_TIME = 0.2              #[s] Must be <= 1/PLANNTER_RATE (we recommend 0.100 for scenarios with <4 vehicles)
+USE_FIXED_PLANNING_TIME = True   #True: the plan will target PLANNING_TIME. False, the planner will vary between PLANNING_TIME and max time (1/PLANNTER_RATE)
+POINTS_PER_METER = 3.0           #The number of points per meter to be used along the vehicle's reference path
+                                 #Note that the value that is used may be slightly different
 
 #Debugging and Log
 PLOT_VEHICLE_ROUTES = False    #If True, will open figures for each of a vehicle's global paths
@@ -72,7 +72,7 @@ PLOT_VEHICLE_ROUTES = False    #If True, will open figures for each of a vehicle
                                #This should only be set when you want to see these figures
                                #The program will crash after showing figures for all vehicles (an XIO error)
 LOG_PERFORMANCE = False
-MAX_NVEHICLES = math.inf              #Limit max number of active vehicles (math.inf if no limit)
+MAX_NVEHICLES = math.inf       #Limit max number of active vehicles (math.inf if no limit)
 EVALUATION_MODE = False
 WRITE_TRAJECTORIES = False     #If True, all vehicle trajectories will be saved inside eval/ as csv files
 

--- a/SimConfig.py
+++ b/SimConfig.py
@@ -15,12 +15,12 @@ ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 #Sim Config
 TIMEOUT = 30                #default timeout in [s] if not defined by scenario
-TRAFFIC_RATE = 30           #global tick rate
+TRAFFIC_RATE = 40           #global tick rate
 WAIT_FOR_INPUT = False      #wait for user input before starting simulation
 
 #Dash Config
 SHOW_DASHBOARD = True      	#show dash with plots, vehicles and trajectories. Optional.
-DASH_RATE = 10              #dash tick rate. Max is traffic rate.
+DASH_RATE = 20              #dash tick rate. Max is traffic rate.
 PLOT_VID = 1               	#vehicle to center the main plot around, if not defined by the scenario.
                             #Make sure there exists a vehicle with this id
 #Global Map
@@ -106,3 +106,5 @@ class SimConfig:
     traffic_rate:int = TRAFFIC_RATE
     plot_vid:int = PLOT_VID
     show_dashboard:bool = SHOW_DASHBOARD
+    wait_for_input:bool = WAIT_FOR_INPUT
+    wait_for_client:bool = WAIT_FOR_CLIENT

--- a/SimConfig.py
+++ b/SimConfig.py
@@ -19,9 +19,9 @@ TRAFFIC_RATE = 40           #global tick rate
 WAIT_FOR_INPUT = False      #wait for user input before starting simulation
 
 #Dash Config
-SHOW_DASHBOARD = True      	#show dash with plots, vehicles and trajectories. Optional.
+SHOW_DASHBOARD = True       #show dash with plots, vehicles and trajectories. Optional.
 DASH_RATE = 20              #dash tick rate. Max is traffic rate.
-PLOT_VID = 1               	#vehicle to center the main plot around, if not defined by the scenario.
+PLOT_VID = 1                #vehicle to center the main plot around, if not defined by the scenario.
                             #Make sure there exists a vehicle with this id
 #Global Map
 SHOW_MPLOT = True           #whether to show the global map cartesian plot
@@ -34,7 +34,7 @@ FFPLOT_LENGTH = 60			#frenet frame plot: road length (s) in meters
 FFPLOT_LITE = False         #frenet frame plot: if true, plots a simplified version with onlye self vehicle. If false, plots all vehicles, trajectories and candidates
 #Cartesian
 SHOW_CPLOT = True           #whether to show the cartesian plot
-CPLOT_SIZE = 100			    #cartesian plot: road length in meters (shorter=better performance)
+CPLOT_SIZE = 100            #cartesian plot: road length in meters (shorter=better performance)
 REFERENCE_PATH = True       #reference path indicating the frenet frame for the vehicle
 SHOW_VEHICLE_SHAPE = True   #vehicle plot with rectangle shape.
 SHOW_VEHICLE_RADIUS = False #vehicle plot with radius.

--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -90,8 +90,8 @@ class SimTraffic(object):
         self.write_traffic_state(0 , 0.0, 0.0)
 
         #If cosimulation, hold start waiting for first client state
-        if self.cosimulation == True and WAIT_FOR_CLIENT:
-            log.warn("GSServer is running in Cosimulation. Waiting for client state in SEM:{} KEY:{}...".format(CS_SEM_KEY, CS_SHM_KEY))
+        if self.cosimulation == True and self.simconfig.wait_for_client:
+            log.warn("GSServer is running in co-simulation. Waiting for client state in SEM:{} KEY:{}...".format(CS_SEM_KEY, CS_SHM_KEY))
             while(True):
                 header, vstates, _, _, _ = self.sim_client_shm.read_client_state(len(self.vehicles), len(self.pedestrians))
                 if len(vstates)>0:


### PR DESCRIPTION
```
usage: GSServer.py [-h] [-s [FILE ...]] [--verify_map FILE] [-q VERBOSE] [-n] [-m MAP_PATH] [-b BTREE_LOCATIONS] [-wi] [-wc]

options:
  -h, --help            show this help message and exit
  -s [FILE ...], --scenario [FILE ...]
                        GeoScenario file. If no file is provided, the GSServer will load a scenario from code
  --verify_map FILE     Lanelet map file
  -q VERBOSE, --quiet VERBOSE
                        don't print messages to stdout
  -n, --no-dash         run without the dashboard
  -m MAP_PATH, --map-path MAP_PATH
                        Set the prefix to append to the value of the attribute `globalconfig->lanelet`
  -b BTREE_LOCATIONS, --btree-locations BTREE_LOCATIONS
                        Add higher priority locations to search for btrees by agent btypes
  -wi, --wait-for-input
                        Wait for the user to press [ENTER] to start the simulation
  -wc, --wait-for-client
                        Wait for a valid client state to start the simulation
```

- fix the bug where the simulation was started before user pressed enter