### PR TITLE
Fix yaw for unreal

### DIFF
--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -90,7 +90,7 @@ class SimTraffic(object):
         self.write_traffic_state(0 , 0.0, 0.0)
 
         #If cosimulation, hold start waiting for first client state
-        if self.cosimulation == True and self.simconfig.wait_for_client:
+        if self.cosimulation == True and self.sim_config.wait_for_client:
             log.warn("GSServer is running in co-simulation. Waiting for client state in SEM:{} KEY:{}...".format(CS_SEM_KEY, CS_SHM_KEY))
             while(True):
                 header, vstates, _, _, _ = self.sim_client_shm.read_client_state(len(self.vehicles), len(self.pedestrians))

--- a/clients/unreal/GeoScenarioModule/GSClient.cpp
+++ b/clients/unreal/GeoScenarioModule/GSClient.cpp
@@ -171,12 +171,11 @@ void AGSClient::ReadServerState(float deltaTime)
 		z *= 100.0f;
 		x_vel *= 100.0f;
 		y_vel *= -100.0f;
-		// Unreal uses degrees instead of radians
+		// Convert from radians to degrees for Unreal
 		yaw = yaw * 180.0f / M_PI;
 
-		// Unreal's y axis is inverted from GS server's.
-		yaw -= 90;
-		// GEngine->AddOnScreenDebugMessage(-1, 0, FColor::Red, FString::Printf(TEXT("Yaw %f"), yaw));
+		// Server yaw is counterclockwise, Unreal is clockwise
+		yaw = 360 - yaw;
 
 		FVector loc = {x, y, z};
 		FRotator rot = {0.0f, yaw, 0.0f};


### PR DESCRIPTION
change yaw from counterclockwise (server) to clockwise (unreal)

Tested in co-simulation with WiseSim and the agents show up correctly.