### PR TITLE
feat(collisionWithVehicle): Collision with a vehicle in violation report

### DIFF
--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -7,17 +7,20 @@
 # dashboard (debug), and external Simulator (Unreal or alternative Graphics engine)
 # --------------------------------------------
 
-from multiprocessing import  Manager, Array
-import numpy as np
-import glog as log
-from copy import copy
 import csv
-from shm.SimSharedMemoryServer import *
-from Actor import *
-from sv.Vehicle import Vehicle
-from sp.Pedestrian import *
-from TrafficLight import TrafficLight
+import glog as log
+import numpy as np
 import time
+
+from copy import copy
+from multiprocessing import  Manager, Array
+
+from Actor import *
+from shm.SimSharedMemoryServer import *
+from sp.Pedestrian import *
+from sv.Vehicle import Vehicle
+from TrafficLight import TrafficLight
+
 try:
     from shm.CarlaSync import *
 except:
@@ -186,10 +189,6 @@ class SimTraffic(object):
         #log.info(self.debug_shdata)
         self.log_trajectories(tick_count, delta_time, sim_time)
 
-        #Collisions at Server Side
-        if self.detect_collisions(tick_count, delta_time, sim_time):
-            return -1
-
         return 0
 
     #Shared Memory:
@@ -260,25 +259,6 @@ class SimTraffic(object):
         if self.carla_sync:
             self.carla_sync.write_server_state(tick_count, delta_time, self.vehicles)
 
-    def detect_collisions(self,tick_count, delta_time, sim_time):
-        for id_va, va in self.vehicles.items():
-            if va.sim_state is not ActorSimState.ACTIVE:
-                continue
-            min_x = (va.state.x - VEHICLE_RADIUS)
-            max_x = (va.state.x + VEHICLE_RADIUS)
-            min_y = (va.state.y - VEHICLE_RADIUS)
-            max_y = (va.state.y + VEHICLE_RADIUS)
-            for id_vb, vb in self.vehicles.items():
-                if vb.sim_state is not ActorSimState.ACTIVE:
-                    continue
-                if id_va != id_vb:
-                    #this filter will be important when we use alternative (and more expensive) collision checking methods
-                    if  (min_x <= vb.state.x <= max_x) and (min_y <= vb.state.y <= max_y):
-                        dist = distance_2p(va.state.x,va.state.y, vb.state.x, vb.state.y)
-                        if  dist < (2*VEHICLE_RADIUS):
-                            log.error("Collision between vehicles {} {}".format(id_va,id_vb))
-                            return True
-        return False
 
     def log_sim_state(self, client_vehicle_states, disabled_vehicles):
         log.info("Collision between vehicles {}".format(disabled_vehicles))

--- a/requirements/RequirementViolationEvents.py
+++ b/requirements/RequirementViolationEvents.py
@@ -51,7 +51,7 @@ class CollisionWithVehicle(UnmetRequirement):
 		# There must be a gap of 5 ticks without collision between collision with the same agent
 		if vid not in collision_state or agent_ticks[agent_id] - 5 > collision_state[vid]:
 			self.raise_it(agent_id, {
-				'collider_id': vid,
+				'colliderId': vid,
 				'message': 'v' + str(agent_id) + ' bounding box overlapped with the vehicle agent v' + str(vid)
 			})
 

--- a/requirements/RequirementViolationEvents.py
+++ b/requirements/RequirementViolationEvents.py
@@ -6,10 +6,11 @@ from multiprocessing import Manager, Value
 manager = Manager()
 
 # Singleton
-agent_ticks  = manager.dict()
-file_name    = os.getenv('VIOLATION_REPORT_FOLDER', './results') + '/violations.json'
-global_tick  = Value('i', -1)
-violations   = manager.dict()
+agent_collisions = manager.dict()
+agent_ticks      = manager.dict()
+file_name        = os.getenv('VIOLATION_REPORT_FOLDER', './results') + '/violations.json'
+global_tick      = Value('i', -1)
+violations       = manager.dict()
 
 # Generic
 class ScenarioEnd:
@@ -36,16 +37,27 @@ class UnmetRequirement:
 class AgentTick:
 	def __init__(self, agent_id):
 		if agent_id not in agent_ticks:
-			agent_ticks[agent_id] = -1
-			violations[agent_id]  = {}
+			agent_collisions[agent_id] = {}
+			agent_ticks[agent_id]      = -1
+			violations[agent_id]       = {}
 
 		agent_ticks[agent_id] += 1
 
+
 class CollisionWithVehicle(UnmetRequirement):
 	def __init__(self, agent_id, vid):
-		self.raise_it(agent_id,
-			'v' + str(agent_id) + ' bounding box overlapped with the vehicle agent v' + str(vid)
-		)
+		collision_state = agent_collisions[agent_id]
+
+		# There must be a gap of 5 ticks without collision between collision with the same agent
+		if vid not in collision_state or agent_ticks[agent_id] - 5 > collision_state[vid]:
+			self.raise_it(agent_id,
+				'v' + str(agent_id) + ' bounding box overlapped with the vehicle agent v' + str(vid)
+			)
+
+		collision_state[vid] = agent_ticks[agent_id]
+
+		# That reassignment is necessary for the update to work in multiprocessing
+		agent_collisions[agent_id] = collision_state
 
 class GlobalTick:
 	def __init__(self):

--- a/requirements/RequirementsChecker.py
+++ b/requirements/RequirementsChecker.py
@@ -1,18 +1,67 @@
-from requirements.RequirementViolationEvents import GoalOvershot, ScenarioCompletion, ScenarioEnd
+import numpy as np
+
+from math import cos, radians, sin
+
+from Actor import ActorSimState
+from requirements.RequirementViolationEvents import CollisionWithVehicle, GoalOvershot, ScenarioCompletion, ScenarioEnd
 from sv.SDVTrafficState import *
 
 class RequirementsChecker:
-	def __init__(self, goal_ends_simulation):
+	def __init__(self, ego_vehicle, goal_ends_simulation):
 		self.conditions = [
+			self.detect_collisions,
 			self.detect_goal_overshot
 		]
 
+		self.ego_vehicle = ego_vehicle
 		self.goal_ends_simulation = goal_ends_simulation
 		self.goal_s_distance = float('inf')
+		self.vehicles = {}
 
 	def analyze(self, traffic_state:TrafficState):
+		self.vehicles = {}
+		self.vehicles.update(traffic_state.traffic_vehicles)
+		self.vehicles.update(traffic_state.traffic_vehicles_orp)
+
 		for condition in self.conditions:
 			condition(traffic_state)
+
+	def calculate_rectangular_bounding_box(self, vehicle):
+		center_x     = vehicle.state.x
+		center_y     = vehicle.state.y
+		half_length  = vehicle.bounding_box_length / 2
+		half_width   = vehicle.bounding_box_width  / 2
+		yaw          = -vehicle.state.yaw
+
+		bottom_left  = self.rotate(center_x, center_y, center_x - half_length, center_y - half_width, yaw)
+		bottom_right = self.rotate(center_x, center_y, center_x + half_length, center_y - half_width, yaw)
+		top_left     = self.rotate(center_x, center_y, center_x - half_length, center_y + half_width, yaw)
+		top_right    = self.rotate(center_x, center_y, center_x + half_length, center_y + half_width, yaw)
+
+		return np.array([top_left, top_right, bottom_right, bottom_left])
+
+	def detect_collisions(self, traffic_state:TrafficState):
+		ego_vehicle       = self.ego_vehicle
+
+		if ego_vehicle.sim_state is not ActorSimState.ACTIVE:
+			return
+
+		ego_box           = self.calculate_rectangular_bounding_box(ego_vehicle)
+
+		min_x = (ego_vehicle.state.x - ego_vehicle.radius)
+		max_x = (ego_vehicle.state.x + ego_vehicle.radius)
+		min_y = (ego_vehicle.state.y - ego_vehicle.radius)
+		max_y = (ego_vehicle.state.y + ego_vehicle.radius)
+
+		for vid, vehicle in self.vehicles.items():
+			if vehicle.sim_state not in [ ActorSimState.ACTIVE, ActorSimState.ACTIVE.value]:
+				continue
+
+			# To avoid O(v²) comparisons and favor O(v) comparisons whenever possible
+			if  (min_x <= vehicle.state.x <= max_x) and (min_y <= vehicle.state.y <= max_y):
+				vehicle_box = self.calculate_rectangular_bounding_box(vehicle)
+				if self.do_polygons_intersect(ego_box, vehicle_box):
+					CollisionWithVehicle(ego_vehicle.id, vid)
 
 
 	def detect_goal_overshot(self, traffic_state:TrafficState):
@@ -50,3 +99,67 @@ class RequirementsChecker:
 			if self.goal_ends_simulation:
 				ScenarioEnd()
 				raise ScenarioCompletion()
+
+	def do_polygons_intersect(self, polygon_a, polygon_b):
+		"""
+		* Reference: https://stackoverflow.com/questions/10962379/how-to-check-intersection-between-2-rotated-rectangles
+		* Determine whether there is an intersection between the two polygons described
+		* by the lists of vertices. Uses the Separating Axis Theorem
+		*
+		* @param a an ndarray of connected points [[x_1, y_1], [x_2, y_2],...] that form a closed polygon
+		* @param b an ndarray of connected points [[x_1, y_1], [x_2, y_2],...] that form a closed polygon
+		* @return true if there is any intersection between the 2 polygons, false otherwise
+		"""
+		polygons = [polygon_a, polygon_b];
+
+		for polygon in polygons:
+			# for each polygon, look at each edge of the polygon, and determine if it separates the two shapes
+			for edge_index in range(len(polygon)):
+
+				# grab 2 vertices to create an edge
+				edge_index_2 = (edge_index + 1) % len(polygon);
+				[ x1, y1 ] = polygon[edge_index];
+				[ x2, y2 ] = polygon[edge_index_2];
+
+				# find the line perpendicular to this edge
+				normal = { 'x': y2 - y1, 'y': x1 - x2 };
+
+				minA, maxA = None, None
+				# for each vertex in the first shape, project it onto the line perpendicular to the edge
+				# and keep track of the min and max of these values
+				for vertex in polygon_a:
+					[vx, vy] = vertex
+					projected = normal['x'] * vx + normal['y'] * vy;
+					
+					if (minA is None) or (projected < minA):
+						minA = projected
+
+					if (maxA is None) or (projected > maxA):
+						maxA = projected
+
+				# for each vertex in the second shape, project it onto the line perpendicular to the edge
+				# and keep track of the min and max of these values
+				minB, maxB = None, None
+				for vertex in polygon_b:
+					[vx, vy] = vertex
+					projected = normal['x'] * vx + normal['y'] * vy
+
+					if (minB is None) or (projected < minB):
+						minB = projected
+
+					if (maxB is None) or (projected > maxB):
+						maxB = projected
+
+				# if there is no overlap between the projects, the edge we are looking at separates the two
+				# polygons, and we know there is no overlap
+				if (maxA < minB) or (maxB < minA):
+					return False;
+
+		return True
+
+	def rotate(self, center_x, center_y, x, y, degree_theta):
+		radian_theta = radians(degree_theta)
+		x2 = center_x + (x - center_x) * cos(radian_theta) + (y - center_y) * sin(radian_theta)
+		y2 = center_y - (x - center_x) * sin(radian_theta) + (y - center_y) * cos(radian_theta)
+
+		return np.array([ x2, y2 ])

--- a/sv/Vehicle.py
+++ b/sv/Vehicle.py
@@ -5,57 +5,28 @@
 # SIMULATED VEHICLES
 # --------------------------------------------
 
-from os import stat_result
-from matplotlib import pyplot as plt
-import math
-import sys
+import datetime
 import glog as log
+import math
 import numpy as np
-from TickSync import TickSync
-from SimConfig import *
-from util.Transformations import frenet_to_sim_frame, sim_to_frenet_frame, OutsideRefPathException
-from util.Utils import *
-from sv.SDVPlanner import *
-from sv.SDVRoute import SDVRoute
+import sys
+
+from matplotlib import pyplot as plt
+from os import stat_result
+from typing import List
+
 from Actor import *
+from gsc.GSParser import Node
+from lanelet2.routing import Route
 from mapping.LaneletMap import LaneletMap
 from requirements.RequirementViolationEvents import ScenarioCompletion
 from shm.SimSharedMemoryServer import *
+from SimConfig import *
+from sv.SDVPlanner import *
+from sv.SDVRoute import SDVRoute
+from sv.VehicleBase import Vehicle
+from util.Transformations import frenet_to_sim_frame, sim_to_frenet_frame, OutsideRefPathException
 from util.Utils import kalman
-from typing import List
-from lanelet2.routing import Route
-from gsc.GSParser import Node
-
-import datetime
-
-# Vehicle base class for remote control or simulation.
-class Vehicle(Actor):
-    #vehicle types
-    N_TYPE = 0      #neutral
-    SDV_TYPE = 1
-    EV_TYPE = 2
-    TV_TYPE = 3
-    PV_TYPE = 4
-
-    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0):
-        super().__init__(id, name, start_state, frenet_state, yaw, VehicleState())
-        self.type = Vehicle.N_TYPE
-        self.radius = VEHICLE_RADIUS
-        self.model = ''
-
-
-    def update_sim_state(self, new_state, delta_time):
-        # NOTE: this may desync the sim and frenet vehicle state, so this should
-        # only be done for external vehicles (which don't have a frenet state)
-        if self.type is not Vehicle.EV_TYPE:
-            log.warn("Cannot update sim state for gs vehicles directly.")
-
-
-    def get_sim_state(self):
-        position = [self.state.x, self.state.y, 0.0]
-        velocity = [self.state.x_vel, self.state.y_vel]
-        return self.id, self.type, position, velocity, self.state.yaw, self.state.steer
-
 
 class SDV(Vehicle):
     ''''

--- a/sv/VehicleBase.py
+++ b/sv/VehicleBase.py
@@ -1,0 +1,32 @@
+from Actor import Actor, VehicleState
+from SimConfig import *
+
+# Vehicle base class for remote control or simulation.
+class Vehicle(Actor):
+    #vehicle types
+    N_TYPE = 0      #neutral
+    SDV_TYPE = 1
+    EV_TYPE = 2
+    TV_TYPE = 3
+    PV_TYPE = 4
+
+    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0):
+        super().__init__(id, name, start_state, frenet_state, yaw, VehicleState())
+        self.bounding_box_length = VEHICLE_LENGTH
+        self.bounding_box_width  = VEHICLE_WIDTH
+        self.model  = ''
+        self.radius = VEHICLE_RADIUS
+        self.type   = Vehicle.N_TYPE
+
+
+    def update_sim_state(self, new_state, delta_time):
+        # NOTE: this may desync the sim and frenet vehicle state, so this should
+        # only be done for external vehicles (which don't have a frenet state)
+        if self.type is not Vehicle.EV_TYPE:
+            log.warn("Cannot update sim state for gs vehicles directly.")
+
+
+    def get_sim_state(self):
+        position = [self.state.x, self.state.y, 0.0]
+        velocity = [self.state.x_vel, self.state.y_vel]
+        return self.id, self.type, position, velocity, self.state.yaw, self.state.steer


### PR DESCRIPTION
Violation report now monitors collision with vehicles.

Previously vehicles bounding boxes where radius and Rodrigo's was relying on a set of constants https://github.com/rodrigoqueiroz/geoscenarioserver/blob/413949943facf9e38c17cb978683bb7cb6428c34/SimConfig.py#L57 that were not correlating with the actor class.

Collision were detected through radius geometry, which mean that except for the case in which two vehicles collide while driving completely in parallel, the collision detections were inaccurate and you had to go pretty deep in a vehicle before the collision trigger. The new collision system use the rectangle geometry and correlates with the vehicle class.

Moreover, a collision do not end the simulation anylonger. The vehicles will go through each other and another collision would only be recorded when there are at least 5 planning ticks for which both vehicles are not overlapping.

I have not updated the dashboard in this PR. Because my dashboard update cannot be separated easily from the perception system because of the pickling involved in the dashboard. I will give that in the next PR.

I have been testing the collision detection on this branch using my orchestrator and it yielded the following output

```
{
  '179': {
    CollisionWithVehicle: 'v1 bounding box overlapped with the vehicle agent v2'
  },
  '447': {
    ScenarioTimeout: 'v1 did not reach its target location during the 90.0 seconds allowed by this scenario.'
  }
}
```

However, I have tested it with a scenario that is not yet public on geoscenario-orchestrator-prod. Mine rely on another agent being controlled by a rule-engine. So you would have to generate a collision manually on your own scenario to replicate since I am not yet ready to publish a new version of geoscenario-orchestrator-prod.