### PR TITLE
ROS2 client receive from co-simulator

### DIFF
--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -103,11 +103,14 @@ class GSClient(Node):
         for msg_vehicle in msg.vehicles:
             vehicle = {}
             vehicle["id"] = msg_vehicle.id
+            vehicle["type"] = msg_vehicle.type # not used
             vehicle["x"] = msg_vehicle.position.x
             vehicle["y"] = msg_vehicle.position.y
             vehicle["z"] = msg_vehicle.position.z
             vehicle["vx"] = msg_vehicle.velocity.x
             vehicle["vy"] = msg_vehicle.velocity.y
+            vehicle["yaw"] = msg_vehicle.yaw # not used
+            vehicle["steering_angle"] = msg_vehicle.steering_angle # not used
             vehicle["active"] = 1
             vehicles.append(vehicle)
 
@@ -115,11 +118,13 @@ class GSClient(Node):
         for msg_pedestrian in msg.pedestrians:
             pedestrian = {}
             pedestrian["id"] = msg_pedestrian.id
+            pedestrian["type"] = msg_pedestrian.type # not used
             pedestrian["x"] = msg_pedestrian.position.x
             pedestrian["y"] = msg_pedestrian.position.y
             pedestrian["z"] = msg_pedestrian.position.z
             pedestrian["vx"] = msg_pedestrian.velocity.x
             pedestrian["vy"] = msg_pedestrian.velocity.y
+            pedestrian["yaw"] = msg_pedestrian.yaw # not used
             pedestrian["active"] = 1
             pedestrians.append(pedestrian)
 

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -11,6 +11,7 @@ class GSClient(Node):
         super().__init__('geoscenario_client')
         self.initialize_state()
         self.tick_pub = self.create_publisher(Tick, '/gs/tick', 10)
+        self.tick_sub = self.create_subscription(Tick, '/gs/tick-in', self.tick_in, 10)
         self.timer = self.create_timer(self.short_timer_period, self.timer_callback)
 
     def initialize_state(self):
@@ -93,6 +94,8 @@ class GSClient(Node):
         self.tick_pub.publish(tick_msg)
         self.previous_tick_count = tick_count
 
+    def tick_in(self, msg):
+        self.sim_client_shm.write_client_state(self, msg.tick_count, msg.sim_time, msg.delta_time, None, msg.vehicles, msg.pedestrians)
 
 def main(args=None):
     rclpy.init(args=args)

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -1,4 +1,3 @@
-import sys
 import rclpy
 from rclpy.node import Node
 from rclpy.executors import ExternalShutdownException
@@ -115,7 +114,7 @@ class GSClient(Node):
             vehicle["vx"] = msg_vehicle.velocity.x
             vehicle["vy"] = msg_vehicle.velocity.y
             vehicle["yaw"] = msg_vehicle.yaw
-            vehicle["steering_angle"] = msg.steering_angle
+            vehicle["steering_angle"] = msg_vehicle.steering_angle
             vehicles.append(vehicle)
 
         pedestrians = []
@@ -131,7 +130,7 @@ class GSClient(Node):
             pedestrian["yaw"] = msg_pedestrian.yaw
             pedestrians.append(pedestrian)
 
-        self.sim_client_shm.write_client_state(self, msg.tick_count, msg.simulation_time, msg.delta_time, origin, vehicles, pedestrians)
+        self.sim_client_shm.write_client_state(msg.tick_count, msg.simulation_time, msg.delta_time, origin, vehicles, pedestrians)
 
 def main(args=None):
     rclpy.init(args=args)

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -98,39 +98,32 @@ class GSClient(Node):
 
     def tick_from_client(self, msg):
         # convert the msg into dictionaries
-        origin = {}
-        origin["origin_lat"] = msg.origin.latitude
-        origin["origin_lon"] = msg.origin.longitude
-        origin["origin_alt"] = msg.origin.altitude
-
+        # ignore origin, simulation_time, type, yaw, steering angle not used in the client
         vehicles = []
         for msg_vehicle in msg.vehicles:
             vehicle = {}
             vehicle["id"] = msg_vehicle.id
-            vehicle["type"] = msg_vehicle.type
             vehicle["x"] = msg_vehicle.position.x
             vehicle["y"] = msg_vehicle.position.y
             vehicle["z"] = msg_vehicle.position.z
             vehicle["vx"] = msg_vehicle.velocity.x
             vehicle["vy"] = msg_vehicle.velocity.y
-            vehicle["yaw"] = msg_vehicle.yaw
-            vehicle["steering_angle"] = msg_vehicle.steering_angle
+            vehicle["active"] = 1
             vehicles.append(vehicle)
 
         pedestrians = []
         for msg_pedestrian in msg.pedestrians:
             pedestrian = {}
             pedestrian["id"] = msg_pedestrian.id
-            pedestrian["type"] = msg_pedestrian.type
             pedestrian["x"] = msg_pedestrian.position.x
             pedestrian["y"] = msg_pedestrian.position.y
             pedestrian["z"] = msg_pedestrian.position.z
             pedestrian["vx"] = msg_pedestrian.velocity.x
             pedestrian["vy"] = msg_pedestrian.velocity.y
-            pedestrian["yaw"] = msg_pedestrian.yaw
+            pedestrian["active"] = 1
             pedestrians.append(pedestrian)
 
-        self.sim_client_shm.write_client_state(msg.tick_count, msg.simulation_time, msg.delta_time, origin, vehicles, pedestrians)
+        self.sim_client_shm.write_client_state(msg.tick_count, msg.delta_time, vehicles, pedestrians)
 
 def main(args=None):
     rclpy.init(args=args)

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -140,11 +140,10 @@ def main(args=None):
 
     try:
         rclpy.spin(gs_client)
-    except KeyboardInterrupt: # SIGINT <ctrl>+c
-        gs_client.get_logger().info('Shutdown keyboard interrupt')
+    except KeyboardInterrupt: # <ctrl>+c
+        gs_client.get_logger().info('Shutdown keyboard interrupt (SIGINT)')
     except ExternalShutdownException:
-        gs_client.get_logger().info('External shutdown') # SIGTERM
-        sys.exit(0)
+        gs_client.get_logger().info('External shutdown (SIGTERM)')
     finally:
         gs_client.destroy_node()
         rclpy.try_shutdown()

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -111,7 +111,7 @@ class GSClient(Node):
             vehicle["vy"] = msg_vehicle.velocity.y
             vehicle["yaw"] = msg_vehicle.yaw # not used
             vehicle["steering_angle"] = msg_vehicle.steering_angle # not used
-            vehicle["active"] = 1
+            vehicle["active"] = msg_vehicle.active
             vehicles.append(vehicle)
 
         pedestrians = []
@@ -125,7 +125,7 @@ class GSClient(Node):
             pedestrian["vx"] = msg_pedestrian.velocity.x
             pedestrian["vy"] = msg_pedestrian.velocity.y
             pedestrian["yaw"] = msg_pedestrian.yaw # not used
-            pedestrian["active"] = 1
+            pedestrian["active"] = msg_vehicle.active
             pedestrians.append(pedestrian)
 
         self.sim_client_shm.write_client_state(msg.tick_count, msg.delta_time, vehicles, pedestrians)

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -1,5 +1,7 @@
+import sys
 import rclpy
 from rclpy.node import Node
+from rclpy.executors import ExternalShutdownException
 
 from geoscenario_msgs.msg import Tick, Pedestrian, Vehicle
 from geographic_msgs.msg import GeoPoint
@@ -11,7 +13,8 @@ class GSClient(Node):
         super().__init__('geoscenario_client')
         self.initialize_state()
         self.tick_pub = self.create_publisher(Tick, '/gs/tick', 10)
-        self.tick_sub = self.create_subscription(Tick, '/gs/tick-in', self.tick_in, 10)
+        self.tick_sub = self.create_subscription(Tick, '/gs/tick_from_client', self.tick_from_client, 10)
+
         self.timer = self.create_timer(self.short_timer_period, self.timer_callback)
 
     def initialize_state(self):
@@ -94,8 +97,41 @@ class GSClient(Node):
         self.tick_pub.publish(tick_msg)
         self.previous_tick_count = tick_count
 
-    def tick_in(self, msg):
-        self.sim_client_shm.write_client_state(self, msg.tick_count, msg.sim_time, msg.delta_time, None, msg.vehicles, msg.pedestrians)
+    def tick_from_client(self, msg):
+        # convert the msg into dictionaries
+        origin = {}
+        origin["origin_lat"] = msg.origin.latitude
+        origin["origin_lon"] = msg.origin.longitude
+        origin["origin_alt"] = msg.origin.altitude
+
+        vehicles = []
+        for msg_vehicle in msg.vehicles:
+            vehicle = {}
+            vehicle["id"] = msg_vehicle.id
+            vehicle["type"] = msg_vehicle.type
+            vehicle["x"] = msg_vehicle.position.x
+            vehicle["y"] = msg_vehicle.position.y
+            vehicle["z"] = msg_vehicle.position.z
+            vehicle["vx"] = msg_vehicle.velocity.x
+            vehicle["vy"] = msg_vehicle.velocity.y
+            vehicle["yaw"] = msg_vehicle.yaw
+            vehicle["steering_angle"] = msg.steering_angle
+            vehicles.append(vehicle)
+
+        pedestrians = []
+        for msg_pedestrian in msg.pedestrians:
+            pedestrian = {}
+            pedestrian["id"] = msg_pedestrian.id
+            pedestrian["type"] = msg_pedestrian.type
+            pedestrian["x"] = msg_pedestrian.position.x
+            pedestrian["y"] = msg_pedestrian.position.y
+            pedestrian["z"] = msg_pedestrian.position.z
+            pedestrian["vx"] = msg_pedestrian.velocity.x
+            pedestrian["vy"] = msg_pedestrian.velocity.y
+            pedestrian["yaw"] = msg_pedestrian.yaw
+            pedestrians.append(pedestrian)
+
+        self.sim_client_shm.write_client_state(self, msg.tick_count, msg.simulation_time, msg.delta_time, origin, vehicles, pedestrians)
 
 def main(args=None):
     rclpy.init(args=args)
@@ -104,12 +140,14 @@ def main(args=None):
 
     try:
         rclpy.spin(gs_client)
-    except KeyboardInterrupt: # Exit (Ctrl-C)
-        gs_client.get_logger().info('Shutdown')
-
-    gs_client.destroy_node()
-
-    rclpy.shutdown()
+    except KeyboardInterrupt: # SIGINT <ctrl>+c
+        gs_client.get_logger().info('Shutdown keyboard interrupt')
+    except ExternalShutdownException:
+        gs_client.get_logger().info('External shutdown') # SIGTERM
+        sys.exit(0)
+    finally:
+        gs_client.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
@@ -10,13 +10,13 @@ class MockCoSimulator(Node):
         
         self.tick_pub = self.create_publisher(Tick, '/gs/tick_from_client', 10)
         self.tick_sub = self.create_subscription(Tick, '/gs/tick', self.tick_from_server, 10)
+        self.get_logger().info('Mock co-simulator started...')
 
     def tick_from_server(self, msg):
-        self.tick_pub(msg)
+        self.tick_pub.publish(msg)
 
-
-if __name__ == '__main__':
-    rclpy.init(args=None)
+def main(args=None):
+    rclpy.init(args=args)
 
     co_simulator = MockCoSimulator()
 
@@ -29,3 +29,6 @@ if __name__ == '__main__':
     finally:
         co_simulator.destroy_node()
         rclpy.try_shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
@@ -1,0 +1,31 @@
+import rclpy
+from rclpy.node import Node
+from rclpy.executors import ExternalShutdownException
+
+from geoscenario_msgs.msg import Tick
+
+class MockCoSimulator(Node):
+    def __init__(self):
+        super().__init__('mock_co_simulator')
+        
+        self.tick_pub = self.create_publisher(Tick, '/gs/tick_from_client', 10)
+        self.tick_sub = self.create_subscription(Tick, '/gs/tick', self.tick_from_server, 10)
+
+    def tick_from_server(self, msg):
+        self.tick_pub(msg)
+
+
+if __name__ == '__main__':
+    rclpy.init(args=None)
+
+    co_simulator = MockCoSimulator()
+
+    try:
+        rclpy.spin(co_simulator)
+    except KeyboardInterrupt: # <ctrl>+c
+        co_simulator.get_logger().info('Shutdown keyboard interrupt (SIGINT)')
+    except ExternalShutdownException:
+        co_simulator.get_logger().info('External shutdown (SIGTERM)')
+    finally:
+        co_simulator.destroy_node()
+        rclpy.try_shutdown()

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/mock_co_simulator.py
@@ -13,6 +13,10 @@ class MockCoSimulator(Node):
         self.get_logger().info('Mock co-simulator started...')
 
     def tick_from_server(self, msg):
+        for v in msg.vehicles:
+            v.active = True
+        for p in msg.pedestrians:
+            p.active = True
         self.tick_pub.publish(msg)
 
 def main(args=None):

--- a/clients/ros2_client/geoscenario_client/setup.py
+++ b/clients/ros2_client/geoscenario_client/setup.py
@@ -24,7 +24,8 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'geoscenario_client = geoscenario_client.geoscenario_client:main'
+            'geoscenario_client = geoscenario_client.geoscenario_client:main',
+            'mock_co_simulator = geoscenario_client.mock_co_simulator:main'
         ],
     },
 )

--- a/clients/ros2_client/geoscenario_msgs/msg/Pedestrian.msg
+++ b/clients/ros2_client/geoscenario_msgs/msg/Pedestrian.msg
@@ -5,3 +5,4 @@ string type
 geometry_msgs/Point position          # [m, m, m], in local cartesian frame defined by the element 'origin'
 geometry_msgs/Vector3 velocity        # [m/s]
 float64 yaw                           # [rad], CCW from east
+bool active                           # provided only by the client to the server

--- a/clients/ros2_client/geoscenario_msgs/msg/Vehicle.msg
+++ b/clients/ros2_client/geoscenario_msgs/msg/Vehicle.msg
@@ -6,3 +6,4 @@ geometry_msgs/Point position          # [m, m, m], in local cartesian frame defi
 geometry_msgs/Vector3 velocity        # [m/s]
 float64 yaw                           # [rad], CCW from east
 float64 steering_angle                # [rad]
+bool active                           # provided only by the client to the server

--- a/shm/SimSharedMemoryClient.py
+++ b/shm/SimSharedMemoryClient.py
@@ -187,7 +187,7 @@ class SimSharedMemoryClient(object):
                 round(vehicle["z"], 4),
                 round(vehicle["vx"], 4),
                 round(vehicle["vy"], 4),
-                vehicle["active"]
+                int(vehicle["active"])
             )
 
         # write pedestrian states, rounding the numerical data to reasonable significant figures
@@ -199,7 +199,7 @@ class SimSharedMemoryClient(object):
                 round(pedestrian["z"], 4),
                 round(pedestrian["vx"], 4),
                 round(pedestrian["vy"], 4),
-                vehicle["active"]
+                int(vehicle["active"])
             )
 
         # sysv_ipc.BusyError needs to be caught

--- a/shm/SimSharedMemoryClient.py
+++ b/shm/SimSharedMemoryClient.py
@@ -1,4 +1,5 @@
 import sysv_ipc
+import math
 import time
 
 SHM_KEY = 123456

--- a/shm/SimSharedMemoryServer.py
+++ b/shm/SimSharedMemoryServer.py
@@ -103,7 +103,7 @@ class SimSharedMemoryServer(object):
         disabled_vehicles = []
         disabled_pedestrians = []
 
-        if not self.is_connected or nvehicles == 0:
+        if not self.is_connected or (nvehicles == 0 and npedestrians == 0):
             return header, vstates, pstates, disabled_vehicles, disabled_pedestrians
 
         # Read client shared memory


### PR DESCRIPTION
The ROS client now listens to `/gs/tick_from_client` topic and writes that to the client shared memory.
Implemented a simple `mock_co_simulator.py` that simply reposts information from `/gs/tick` (aka "tick from server") to `/gs/tick_from_client`.

It turns out that the shared memory for client layout is different than that of the server:
Client shared memory:
```
tick_count delta_time n_vehicles n_pedestrians
vid x y z vx vy active
pid x y z vx vy active
```
Server shared memory:
```
tick_count simulation_time delta_time n_vehicles n_pedestrians
origin_lat origin_lon origin_alt
vid v_type x y z vx vy yaw steering_angle
pid p_type x y z vx vy yaw
```
In particular, the field `active` is not available in the messages `Vehicle` and `Pedestrian`. It might have to be added.

Testing (the exact order does not matter):
0. install ROS2 and build the client
```
$ bash scripts/setup-conda-forge-env.bash --ros2
```
1. start rqt (need to source so that the `geoscenario_msgs` are available for RQT)
```
$ micromamba -n gss run bash -c 'source /home/ma/geoscenarioserver/colcon_ws/install/setup.bash && rqt &'
```
2. start a scenario 
```
$ micromamba -n gss run python3 GSServer.py -s scenarios/coretest_scenarios/straightdrive.gs.osm --no-dash -wi
```
3. start the mock co-simulator
```
$ micromamba -n gss run bash -c 'source /home/ma/geoscenarioserver/colcon_ws/install/setup.bash && ros2 run geoscenario_client mock_co_simulator'
```
4. start the ROS2 client
```
$ micromamba -n gss run bash -c 'source /home/ma/geoscenarioserver/colcon_ws/install/setup.bash && ros2 run geoscenario_client geoscenario_client'
```
Observe `rqt` topics.
![image](https://github.com/user-attachments/assets/f0b74d45-ca59-411c-bc5e-37c3b9414059)

Additional changes:
- clean shutdown to handle SIGINT and SIGTERM