### PR TITLE
migrated pedestrian collision check from planner to SimTraffic

### DIFF
--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -20,6 +20,8 @@ from shm.SimSharedMemoryServer import *
 from sp.Pedestrian import *
 from sv.Vehicle import Vehicle
 from TrafficLight import TrafficLight
+from requirements import RequirementsChecker
+from Actor import ActorSimState
 
 try:
     from shm.CarlaSync import *
@@ -84,6 +86,13 @@ class SimTraffic(object):
 
     def add_static_obect(self, oid, x,y):
         self.static_objects[oid] = StaticObject(oid,x,y)
+
+    def collision_check(self, pedestrian):
+        for vid, vehicle in self.vehicles.items():
+            if vehicle.type == Vehicle.SDV_TYPE:
+                _requirementsChecker = RequirementsChecker(vehicle, False)
+                _requirementsChecker.collision_check(vid, pedestrian.id, [pedestrian.state.x, pedestrian.state.y], vehicle, pedestrian.PEDESTRIAN_RADIUS)
+                print(vid, vehicle)
 
     def start(self):
         self.traffic_running = True
@@ -178,6 +187,10 @@ class SimTraffic(object):
         #tick pedestrians:
         for pid in self.pedestrians:
             self.pedestrians[pid].tick(tick_count, delta_time, sim_time)
+            if self.pedestrians[pid].sim_state not in [ActorSimState.ACTIVE, ActorSimState.ACTIVE.value]:
+                continue
+            self.collision_check(self.pedestrians[pid])
+
         Pedestrian.VEHICLES_POS = {}
 
         #Update traffic light states

--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -92,7 +92,6 @@ class SimTraffic(object):
             if vehicle.type == Vehicle.SDV_TYPE:
                 _requirementsChecker = RequirementsChecker(vehicle, False)
                 _requirementsChecker.collision_check(vid, pedestrian.id, [pedestrian.state.x, pedestrian.state.y], vehicle, pedestrian.PEDESTRIAN_RADIUS)
-                print(vid, vehicle)
 
     def start(self):
         self.traffic_running = True

--- a/TickSync.py
+++ b/TickSync.py
@@ -117,7 +117,7 @@ class TickSync():
     def write_peformance_log(self):
         if LOG_PERFORMANCE:
             logtime = time.strftime("%Y%m%d-%H%M%S")
-            filename = "log/{}_performance_log.csv".format(self.label)
+            filename = f"outputs/{self.label}_performance_log.csv"
             log.info('Writting performance log: {}'.format(filename))
             with open(filename,mode='w') as csv_file:
                 csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)

--- a/requirements/RequirementViolationEvents.py
+++ b/requirements/RequirementViolationEvents.py
@@ -23,7 +23,6 @@ class ScenarioEnd:
 
 class UnmetRequirement:
 	def raise_it(self, agent_id, payload):
-		print(payload)
 		agent_logs = violations[agent_id]
 		agent_tick = agent_ticks[agent_id]
 

--- a/requirements/RequirementViolationEvents.py
+++ b/requirements/RequirementViolationEvents.py
@@ -12,7 +12,7 @@ file_name        = os.path.join(os.getenv("GSS_OUTPUTS", os.path.join(os.getcwd(
                                 "violations.json")
 global_tick      = Value('i', -1)
 violations       = manager.dict()
-TICKS_REQUIRED_WITHOUT_OVERLAPING_THIS_ACTOR = 5
+TICKS_REQUIRED_WITHOUT_OVERLAPING_THIS_ACTOR = 7
 
 # Generic
 class ScenarioEnd:
@@ -23,6 +23,7 @@ class ScenarioEnd:
 
 class UnmetRequirement:
 	def raise_it(self, agent_id, payload):
+		print(payload)
 		agent_logs = violations[agent_id]
 		agent_tick = agent_ticks[agent_id]
 
@@ -65,7 +66,6 @@ class CollisionWithVehicle(UnmetRequirement):
 class CollisionWithPedestrian(UnmetRequirement):
 	def __init__(self, agent_id, pid, collision_zone, relative_angle):
 		collision_state = agent_collisions[agent_id]
-	
 
 		if pid not in collision_state or agent_ticks[agent_id] - TICKS_REQUIRED_WITHOUT_OVERLAPING_THIS_ACTOR > collision_state[pid]:
 			self.raise_it(agent_id, {

--- a/sp/Pedestrian.py
+++ b/sp/Pedestrian.py
@@ -261,7 +261,7 @@ class SP(Pedestrian):
 
         return fiW
 
-    def vehicle_interaction(self, curr_pos, vehicle):
+    def vehicle_interaction(self, curr_pos, curr_vel, vehicle):
         A = 20
         B = 0.1
         lambda_i = 0.5


### PR DESCRIPTION
Previously pedestrian collision detection was one on the planner for each individual vehicle. Because the rate of which the collisions were being detected and the traffic data is updated is significant, the detection is not always recorded. 

Test with pedestrian scenarios and check if the position of the collision indeed is accurate. 

sample output for a right collision: `{"1": {"14": {"CollisionWithPedestrian": {"colliderId": 1, "message": "v1 bounding box overlapped with the pedestrian agent p1 on the vehicles right side at -26.63 degrees", "angle": -26.63, "zone": "right"}}}}`