### PR TITLE
fixed vehicle not recording performance log if successfully exits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode/
 outputs/*.json
 outputs/*.png
+outputs/*.csv
 colcon_ws/
 
 # pixi environments

--- a/GSServer.py
+++ b/GSServer.py
@@ -76,7 +76,7 @@ def start_server(args, m=MVelKeepConfig()):
         log.error("Failed to load scenario")
         return
 
-    sync_global = TickSync(rate=sim_config.traffic_rate, realtime=True, block=True, verbose=False, label="EX")
+    sync_global = TickSync(rate=sim_config.traffic_rate, realtime=True, block=True, verbose=False, label="traffic")
     sync_global.set_timeout(sim_config.timeout)
 
     #find screen info 

--- a/GSServer.py
+++ b/GSServer.py
@@ -27,7 +27,7 @@ from SimConfig import SimConfig
 from SimTraffic import SimTraffic
 from TickSync import TickSync
 
-def start_server(args, m=MVelKeepConfig()):
+def start_server(args):
     # log.setLevel("INFO")
     log.info('GeoScenario server START')
     lanelet_map = LaneletMap()
@@ -145,8 +145,10 @@ def start_server(args, m=MVelKeepConfig()):
     else:
         log.warn("Dashboard will not start")
 
+    dashboard_interrupted = False
     while sync_global.tick():
         if sim_config.show_dashboard and not dashboard._process.is_alive(): # might/might not be wanted
+            dashboard_interrupted = True
             break
         try:
             #Update Traffic
@@ -164,9 +166,9 @@ def start_server(args, m=MVelKeepConfig()):
             log.error(e)
             break
     sync_global.write_performance_log()
-    traffic.stop_all()
+    traffic.stop_all(dashboard_interrupted)
 
-    if sim_config.show_dashboard:
+    if sim_config.show_dashboard and dashboard._process.is_alive():
         dashboard.quit()
 
     #SIM END

--- a/GSServer.py
+++ b/GSServer.py
@@ -163,7 +163,7 @@ def start_server(args, m=MVelKeepConfig()):
         except Exception as e:
             log.error(e)
             break
-    sync_global.write_peformance_log()
+    sync_global.write_performance_log()
     traffic.stop_all()
 
     if sim_config.show_dashboard:

--- a/SimConfig.py
+++ b/SimConfig.py
@@ -20,7 +20,7 @@ WAIT_FOR_INPUT = False      #wait for user input before starting simulation
 
 #Dash Config
 SHOW_DASHBOARD = True       #show dash with plots, vehicles and trajectories. Optional.
-DASH_RATE = 20              #dash tick rate. Max is traffic rate.
+DASH_RATE = 10              #dash tick rate. Max is traffic rate.
 PLOT_VID = 1                #vehicle to center the main plot around, if not defined by the scenario.
                             #Make sure there exists a vehicle with this id
 #Global Map

--- a/SimTraffic.py
+++ b/SimTraffic.py
@@ -123,14 +123,14 @@ class SimTraffic(object):
             if pedestrian.type == Pedestrian.SP_TYPE:
                 pedestrian.start_planner()
 
-    def stop_all(self):
+    def stop_all(self, interrupted = False):
         self.traffic_running = False
         if self.carla_sync:
             self.carla_sync.quit()
 
         self.write_log_trajectories()
         for vid in self.vehicles:
-            self.vehicles[vid].stop()
+            self.vehicles[vid].stop(interrupted)
         for pid in self.pedestrians:
             self.pedestrians[pid].stop()
 

--- a/TickSync.py
+++ b/TickSync.py
@@ -114,7 +114,7 @@ class TickSync():
             log.info('{:05.2f}s {} Tick {:3}# +{:.3f} e{:.3f} d{:.3f} '.
                     format(self.sim_time,self.label,self.tick_count, self.delta_time, self.expected_tick_duration, self.drift))
         
-    def write_peformance_log(self):
+    def write_performance_log(self):
         if LOG_PERFORMANCE:
             logtime = time.strftime("%Y%m%d-%H%M%S")
             filename = f"outputs/{self.label}_performance_log.csv"

--- a/TickSync.py
+++ b/TickSync.py
@@ -118,7 +118,7 @@ class TickSync():
         if LOG_PERFORMANCE:
             logtime = time.strftime("%Y%m%d-%H%M%S")
             filename = f"outputs/{self.label}_performance_log.csv"
-            log.info('Writting performance log: {}'.format(filename))
+            log.info('Writing performance log: {}'.format(filename))
             with open(filename,mode='w') as csv_file:
                 csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
                 titleline =['tickcount', 'sim_time','delta_time', 'drift']

--- a/dash/Dashboard.py
+++ b/dash/Dashboard.py
@@ -70,6 +70,7 @@ class Dashboard(object):
     def run_dash_process(self, traffic_state_sharr, debug_shdata):
         self.window = self.create_gui()
         sync_dash = TickSync(DASH_RATE, realtime=True, block=True, verbose=False, label="dash")
+        self.window.protocol("WM_DELETE_WINDOW", lambda arg=self.window: (sync_dash.write_performance_log(), arg.destroy()))
 
         while sync_dash.tick():
             if not self.window:

--- a/dash/Dashboard.py
+++ b/dash/Dashboard.py
@@ -15,6 +15,7 @@ import tkinter as tk
 from tkinter import ttk
 from tkinter.font import Font
 import datetime
+from signal import signal, SIGTERM, SIGINT
 from PIL import Image, ImageTk
 import glog as log
 from SimTraffic import *
@@ -70,8 +71,12 @@ class Dashboard(object):
     def run_dash_process(self, traffic_state_sharr, debug_shdata):
         self.window = self.create_gui()
         sync_dash = TickSync(DASH_RATE, realtime=True, block=True, verbose=False, label="dash")
+        # handle user closing the window
         self.window.protocol("WM_DELETE_WINDOW", lambda arg=self.window: (sync_dash.write_performance_log(), arg.destroy()))
-
+        # handle process termination sent from quit()
+        signal(SIGTERM, lambda s, f: sync_dash.write_performance_log())
+        # handle user's <CTRL>+C
+        signal(SIGINT, lambda s, f: sync_dash.write_performance_log())
         while sync_dash.tick():
             if not self.window:
                 return

--- a/dash/Dashboard.py
+++ b/dash/Dashboard.py
@@ -69,7 +69,7 @@ class Dashboard(object):
 
     def run_dash_process(self, traffic_state_sharr, debug_shdata):
         self.window = self.create_gui()
-        sync_dash = TickSync(DASH_RATE, realtime=True, block=True, verbose=False, label="DP")
+        sync_dash = TickSync(DASH_RATE, realtime=True, block=True, verbose=False, label="dash")
 
         while sync_dash.tick():
             if not self.window:

--- a/requirements/RequirementViolationEvents.py
+++ b/requirements/RequirementViolationEvents.py
@@ -45,6 +45,13 @@ class AgentTick:
 
 		agent_ticks[agent_id] += 1
 
+class ScenarioInterrupted(UnmetRequirement):
+	def __init__(self, agent_id):
+		self.raise_it(agent_id, {
+			'agentId': agent_id,
+			'message': 'v' + str(agent_id) + ' scenario interrupted by the user'
+		})
+		ScenarioEnd()
 
 class CollisionWithVehicle(UnmetRequirement):
 	def __init__(self, agent_id, vid):

--- a/requirements/RequirementsChecker.py
+++ b/requirements/RequirementsChecker.py
@@ -107,11 +107,6 @@ class RequirementsChecker:
 				ScenarioEnd()
 				raise ScenarioCompletion()
 	
-	def forced_exit(self):
-		#store data upon forced exit
-		ScenarioEnd()
-		raise ScenarioCompletion
-
 	def do_polygons_intersect(self, polygon_a, polygon_b):
 		"""
 		* Reference: https://stackoverflow.com/questions/10962379/how-to-check-intersection-between-2-rotated-rectangles

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -106,7 +106,7 @@ class SVPlanner(object):
         log.info('PLANNER PROCESS START for Vehicle {}'.format(self.vid))
         signal(SIGTERM, self.before_exit)
 
-        self.sync_planner = TickSync(rate=PLANNER_RATE, realtime=True, block=True, verbose=False, label="PP{}".format(self.vid))
+        self.sync_planner = TickSync(rate=PLANNER_RATE, realtime=True, block=True, verbose=False, label=f"planner_v{self.vid}")
 
 
         #Behavior Layer

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -15,7 +15,7 @@ from Actor import *
 from mapping.LaneletMap import *
 from mapping.LaneletMap import LaneletMap
 from requirements.RequirementsChecker import RequirementsChecker
-from requirements.RequirementViolationEvents import AgentTick, ScenarioCompletion
+from requirements.RequirementViolationEvents import AgentTick, ScenarioCompletion, ScenarioInterrupted
 from SimTraffic import *
 from sv.FrenetTrajectory import *
 from sv.ManeuverConfig import *
@@ -73,6 +73,7 @@ class SVPlanner(object):
         if self._process:
             log.info("Terminate Planner Process - vehicle {}".format(self.vid))
             self._process.terminate()
+            self._process.join()
 
     def get_plan(self):
         # TODO: knowledge of reference path changing should be written even if trajectory is invalid
@@ -266,10 +267,10 @@ class SVPlanner(object):
                 self.completion.value = True
 
         except KeyboardInterrupt as e:
-            self._requirementsChecker.forced_exit()
+            ScenarioInterrupted(self.vid)
 
-        except SystemExit as e:
-            self._requirementsChecker.forced_exit()
+        except SystemExit:
+            pass # just normal
 
         log.info('PLANNER PROCESS END. Vehicle{}'.format(self.vid))
         

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -99,7 +99,7 @@ class SVPlanner(object):
     #==SUB PROCESS=============================================
     def before_exit(self,*args):
         if self.sync_planner:
-            self.sync_planner.write_peformance_log()
+            self.sync_planner.write_performance_log()
         sys.exit(0)
 
     def run_planner_process(self, traffic_state_sharr, mplan_sharr, debug_shdata):
@@ -268,10 +268,14 @@ class SVPlanner(object):
         except KeyboardInterrupt as e:
             self._requirementsChecker.forced_exit()
 
-        except SystemExit:
+        except SystemExit as e:
             self._requirementsChecker.forced_exit()
 
         log.info('PLANNER PROCESS END. Vehicle{}'.format(self.vid))
+        
+        #record the log after ending planner process
+        if self.sync_planner:
+            self.sync_planner.write_performance_log()
 
     def write_motion_plan(self, mplan_sharr, plan:MotionPlan):
         if not plan:

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -15,7 +15,7 @@ from Actor import *
 from mapping.LaneletMap import *
 from mapping.LaneletMap import LaneletMap
 from requirements.RequirementsChecker import RequirementsChecker
-from requirements.RequirementViolationEvents import AgentTick, ScenarioCompletion, ScenarioInterrupted
+from requirements.RequirementViolationEvents import AgentTick, ScenarioCompletion, ScenarioInterrupted, ScenarioEnd
 from SimTraffic import *
 from sv.FrenetTrajectory import *
 from sv.ManeuverConfig import *
@@ -270,7 +270,7 @@ class SVPlanner(object):
             ScenarioInterrupted(self.vid)
 
         except SystemExit:
-            pass # just normal
+            ScenarioEnd()
 
         log.info('PLANNER PROCESS END. Vehicle{}'.format(self.vid))
         

--- a/sv/SDVPlanner.py
+++ b/sv/SDVPlanner.py
@@ -284,7 +284,7 @@ class SVPlanner(object):
         #write motion plan
         mplan_sharr.acquire() #<=========LOCK
         mplan_sharr[:] = plan.get_plan_vector()
-        #print('Writting Sh Data VP')
+        #print('Writing Sh Data VP')
         #print(mplan_sharr)
         mplan_sharr.release() #<=========RELEASE
 

--- a/sv/Vehicle.py
+++ b/sv/Vehicle.py
@@ -85,9 +85,9 @@ class SDV(Vehicle):
         self.sv_planner = SVPlanner(self, self.sim_traffic, self.btree_locations, self.route_nodes, self.goal_ends_simulation, self.rule_engine_port)
         self.sv_planner.start()
 
-    def stop(self):
+    def stop(self, interrupted = False):
         if self.sv_planner:
-            self.sv_planner.stop()
+            self.sv_planner.stop(interrupted)
 
     def tick(self, tick_count:int, delta_time:float, sim_time:float):
         if self.goal_ends_simulation and self.sv_planner.completion.value:


### PR DESCRIPTION
Addressing issue #158 

previously only the performance log is recorded when the function exits on a SIGTERM signal. The performance log was not recorded if the function successfully finishes. 

Added functionality to record the performance log upon successfully finishing the plan in SDVPlanner.py.

Can be tested with scenario "coretest_scenarios/obstacles_follow.gs.osm" and will store the performance log `planner_v1_performance_log` and `planner_v2_performance_log` in outputs along with `traffic_performance_log`. 