### PR TITLE
Skip Replanning in STOP Maneuver if Stop Point is extremely close

### DIFF
--- a/sv/ManeuverModels.py
+++ b/sv/ManeuverModels.py
@@ -361,13 +361,6 @@ def plan_stop(vid, mconfig:MStopConfig, traffic_state:TrafficState):
     expected_time = 2*stop_distance / (vehicle_state.s_vel) #assuming uniform acceleration
     target_time = MP(expected_time,40,6) #bound >40% recommended for safely finding a suitable stop time
     
-    # within a certain distance generating new trajectory doesn't make sense
-    if target_pos < 1: 
-        #or abs(target_pos - vehicle_state.s) < 1:
-        log.warn('PLAN STOP Vehicle {} target position {} is too close or behind'.format(vid,target_pos))
-        #mconfig.type = MStopConfig.Type.NOW
-        #s_solver = quartic_polynomial_solver
-        return None, None
 
     # when vehicle is past the target point, switch to STOP NOW
     #if (target_pos - vehicle_state.s) < 0:
@@ -512,3 +505,13 @@ def find_trajectory(traj_bounds,
     s_coef = s_solver(s_start, s_target, t)
     d_coef = d_solver(d_start, d_target, t)
     return tuple([s_coef, d_coef, t])
+
+def determine_skip_replanning(mconfig):
+
+    # within a certain distance generating new trajectory doesn't make sense
+    if (mconfig.mkey == Maneuver.M_STOP):
+        target_pos = mconfig.pos - VEHICLE_LENGTH/2 - mconfig.distance 
+        if target_pos < 1: 
+            return True
+
+    return False


### PR DESCRIPTION
re: https://github.com/rodrigoqueiroz/geoscenarioserver/issues/154

Hey @drodeur. Quick update on this. We chatted briefly on Wednesday and agreed probably the best solution is to (silently) continue on the previous trajectory given we are presuming the existing trajectory is feasible - essentially skipping replanning if the stop point is less then 1m away from the vehicle. This was already what the planner was doing, but now it shouldn't raise an invalid trajectory message in the log. This implemented here. Let me know if this solution isn't amenable to you. 