### PR TITLE
An option to use WGS84 coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ pixi run regenerate
 
 To run automated test of ROS2 client using the mock co-simulator, execute:
 ```
-bash geoscenarioserver/scripts/pixi_test_ros2_client.bash [--wgs84]
+bash geoscenarioserver/scripts/pixi_test_ros2_client.bash [--wgs84|--roundtriptest]
 ```
 By default, the client will use local coordinates.
 Use `--wgs84` flag to convert to and from WGS84 coordinates.
+Use `--roundtriptest` flag to enable round-trip testing in addition to WGS84 conversion.
 
-Finally, to activate the environment and execute arbitary commands without ROS2, execute
+Finally, to activate the environment and execute arbitrary commands without ROS2, execute
 ```
 cd geoscenarioserver
 pixi shell

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ pixi run rqt
 pixi run ros_client_build
 pixi run ros_client
 pixi run ros_client_wgs84
+pixi run ros_client_wgs84_roundtriptest
 pixi run ros_mock_co_simulator
 pixi run regenerate
 ```

--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ pixi run test_scenarios_ci
 pixi run rqt
 pixi run ros_client_build
 pixi run ros_client
+pixi run ros_client_wgs84
 pixi run ros_mock_co_simulator
 pixi run regenerate
 ```
 
 To run automated test of ROS2 client using the mock co-simulator, execute:
 ```
-bash geoscenarioserver/scripts/pixi_test_ros2_client.bash
+bash geoscenarioserver/scripts/pixi_test_ros2_client.bash [--wgs84]
 ```
+By default, the client will use local coordinates.
+Use `--wgs84` flag to convert to and from WGS84 coordinates.
 
 Finally, to activate the environment and execute arbitary commands without ROS2, execute
 ```

--- a/clients/ros2_client/README.md
+++ b/clients/ros2_client/README.md
@@ -15,3 +15,5 @@ The argument `wgs84:=true` (`false` by default) changes the coordinate frame to 
 
 A ROS2 subscriber to `/tick` can determine that WGS84 coordinates are used if `/tick/origin=(0,0,0)`.
 
+The client can execute a round-trip test: store values from server shared memory, convert to WGS84, send to mock co-simulator, receive, convert from WGS84, compare with stored.
+The argument `roundtriptest:=true` (`false` by default) enables this round-trip test.

--- a/clients/ros2_client/README.md
+++ b/clients/ros2_client/README.md
@@ -1,0 +1,17 @@
+# GeoScenarioServer shared memory client for ROS2
+
+The `ros2_client` interfaces between GSS shared memory and ROS2 topics:
+1. reads from GSS shared memory block for server and publishes to `/tick`
+2. subscribes to `/tick_from_client` and writes to GSS shared memory block for client
+
+## Usage
+
+```
+ros2 run geoscenario_client geoscenario_client [--ros-args -p wgs84:=true]
+```
+
+The client publishes the coordinates in a local cartesian frame defined by the scenario's origin. 
+The argument `wgs84:=true` (`false` by default) changes the coordinate frame to WGS84 instead of local cartesian coordinates.
+
+A ROS2 subscriber to `/tick` can determine that WGS84 coordinates are used if `/tick/origin=(0,0,0)`.
+

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -199,9 +199,16 @@ class GSClient(Node):
         if self.roundtrip_test:
             # check if the tick matches the one we sent
             if msg.tick_count in self.ticks:
-                diff = DeepDiff(self.ticks[msg.tick_count]["vehicles"][0], vehicles[0], ignore_order=True)
-                if diff:
-                    self.get_logger().error(f"Roundtrip test failed for tick {msg.tick_count}: {diff}")
+                if len(self.ticks[msg.tick_count]["vehicles"]) > 0:
+                    # compare the first vehicle only
+                    diff = DeepDiff(self.ticks[msg.tick_count]["vehicles"][0], vehicles[0], ignore_order=True)
+                    if diff:
+                        self.get_logger().error(f"Roundtrip test failed, tick({msg.tick_count}), vehicle(0):\n {diff['values_changed']}")
+                if len(self.ticks[msg.tick_count]["pedestrians"]) > 0:
+                    # compare the first pedestrian only
+                    diff = DeepDiff(self.ticks[msg.tick_count]["pedestrians"][0], pedestrians[0], ignore_order=True)
+                    if diff:
+                        self.get_logger().error(f"Roundtrip test failed, tick({msg.tick_count}), pedestrian(0):\n {diff['values_changed']}")
             else:
                 self.get_logger().error(f"Received tick {msg.tick_count} not found in stored ticks")
 

--- a/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
+++ b/clients/ros2_client/geoscenario_client/geoscenario_client/geoscenario_client.py
@@ -201,12 +201,12 @@ class GSClient(Node):
             if msg.tick_count in self.ticks:
                 if len(self.ticks[msg.tick_count]["vehicles"]) > 0:
                     # compare the first vehicle only
-                    diff = DeepDiff(self.ticks[msg.tick_count]["vehicles"][0], vehicles[0], ignore_order=True)
+                    diff = DeepDiff(self.ticks[msg.tick_count]["vehicles"][0], vehicles[0], ignore_order=True, significant_digits=9)
                     if diff:
                         self.get_logger().error(f"Roundtrip test failed, tick({msg.tick_count}), vehicle(0):\n {diff['values_changed']}")
                 if len(self.ticks[msg.tick_count]["pedestrians"]) > 0:
                     # compare the first pedestrian only
-                    diff = DeepDiff(self.ticks[msg.tick_count]["pedestrians"][0], pedestrians[0], ignore_order=True)
+                    diff = DeepDiff(self.ticks[msg.tick_count]["pedestrians"][0], pedestrians[0], ignore_order=True, significant_digits=9)
                     if diff:
                         self.get_logger().error(f"Roundtrip test failed, tick({msg.tick_count}), pedestrian(0):\n {diff['values_changed']}")
             else:

--- a/clients/ros2_client/geoscenario_client/package.xml
+++ b/clients/ros2_client/geoscenario_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>geoscenario_client</name>
-  <version>0.0.2</version>
+  <version>0.1.0</version>
   <description>Python client for GeoScenarioServer</description>
   <maintainer email="ian.colwell@hexagon.com">Ian Colwell</maintainer>
   <maintainer email="michal.antkiewicz@uwaterloo.ca">Michal Antkiewicz</maintainer>

--- a/clients/ros2_client/geoscenario_client/setup.py
+++ b/clients/ros2_client/geoscenario_client/setup.py
@@ -4,7 +4,7 @@ package_name = 'geoscenario_client'
 
 setup(
     name=package_name,
-    version='0.0.2',
+    version='0.1.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/clients/ros2_client/geoscenario_msgs/CMakeLists.txt
+++ b/clients/ros2_client/geoscenario_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(geoscenario_msgs)
+project(geoscenario_msgs VERSION 0.1.0)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)

--- a/clients/ros2_client/geoscenario_msgs/msg/Pedestrian.msg
+++ b/clients/ros2_client/geoscenario_msgs/msg/Pedestrian.msg
@@ -2,8 +2,9 @@ uint16 id
 string type
 
 # State
-geometry_msgs/Point position          # [m, m, m], in local cartesian frame defined by the element 'origin'
-geometry_msgs/Vector3 velocity        # [m/s, m/s, m/s] along X, Y, Z axes
-geometry_msgs/Vector3 dimensions      # [m, m, m] along X, Y, Z axes
-float64 yaw                           # [rad], CCW from east
-bool active                           # provided only by the client to the server
+geometry_msgs/Point position        # [m, m, m], in local cartesian frame defined by the element 'origin'
+                                    # [deg, deg, m] in WGS84 when origin=(0,0,0)
+geometry_msgs/Vector3 velocity      # [m/s, m/s, m/s] along X, Y, Z axes
+geometry_msgs/Vector3 dimensions    # [m, m, m] along X, Y, Z axes
+float64 yaw                         # [rad], CCW from east
+bool active                         # provided only by the client to the server

--- a/clients/ros2_client/geoscenario_msgs/msg/Tick.msg
+++ b/clients/ros2_client/geoscenario_msgs/msg/Tick.msg
@@ -4,6 +4,7 @@ uint32 tick_count
 float64 simulation_time         # [s] Time passed since the beginning of the simulation
 float64 delta_time              # [s] Time passed since last tick
 geographic_msgs/GeoPoint origin # [deg, deg, m], in WGS84 (EPSG: 4326)
+                                # origin=(0,0,0) indicates that WGS84 coordinates are used
 
 geoscenario_msgs/Vehicle[] vehicles
 geoscenario_msgs/Pedestrian[] pedestrians

--- a/clients/ros2_client/geoscenario_msgs/msg/Vehicle.msg
+++ b/clients/ros2_client/geoscenario_msgs/msg/Vehicle.msg
@@ -2,9 +2,10 @@ uint16 id
 string type
 
 # State
-geometry_msgs/Point position          # [m, m, m], in local cartesian frame defined by the element 'origin'
-geometry_msgs/Vector3 velocity        # [m/s, m/s, m/s] along X, Y, Z axes
-geometry_msgs/Vector3 dimensions      # [m, m, m] along X, Y, Z axes
-float64 yaw                           # [rad], CCW from east
-float64 steering_angle                # [rad]
-bool active                           # provided only by the client to the server
+geometry_msgs/Point position        # [m, m, m], in local cartesian frame defined by the element 'origin'
+                                    # [deg, deg, m] in WGS84 when origin=(0,0,0)
+geometry_msgs/Vector3 velocity      # [m/s, m/s, m/s] along X, Y, Z axes
+geometry_msgs/Vector3 dimensions    # [m, m, m] along X, Y, Z axes
+float64 yaw                         # [rad], CCW from east
+float64 steering_angle              # [rad]
+bool active                         # provided only by the client to the server

--- a/clients/ros2_client/geoscenario_msgs/package.xml
+++ b/clients/ros2_client/geoscenario_msgs/package.xml
@@ -2,9 +2,10 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>geoscenario_msgs</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>Message package for geoscenario</description>
-  <maintainer email="ian.colwell@hexagon.com">Ian</maintainer>
+  <maintainer email="michal.antkiewicz@uwaterloo.ca">Michal Antkiewicz</maintainer>
+  <maintainer email="ian.colwell@hexagon.com">Ian Colwell</maintainer>
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/pixi.lock
+++ b/pixi.lock
@@ -401,6 +401,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deepdiff-8.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
@@ -634,6 +635,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/orderly-set-5.4.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-h5888daf_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/osrf_pycommon-0.2.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -2185,6 +2187,19 @@ packages:
   purls: []
   size: 618596
   timestamp: 1640112124844
+- conda: https://conda.anaconda.org/conda-forge/noarch/deepdiff-8.5.0-pyhd8ed1ab_0.conda
+  sha256: 25f8bf4c2727874e0ad71794b784611de2c85c339f0ae0a5e581202a33eac07a
+  md5: adbda62a2137571fcecc74e3eb139c6f
+  depends:
+  - orderly-set >=5.4.1,<6
+  - python >=3.9
+  channel: https://fast.prefix.dev/conda-forge
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/deepdiff?source=hash-mapping
+  size: 74931
+  timestamp: 1746837116800
 - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
   sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
   md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
@@ -5635,6 +5650,19 @@ packages:
   purls: []
   size: 3117410
   timestamp: 1746223723843
+- conda: https://conda.anaconda.org/conda-forge/noarch/orderly-set-5.4.1-pyhe01879c_0.conda
+  sha256: d1c3dc9078e5a7e05692581bdcd5b51fd9bf5c676b43174452399d92d0fbc929
+  md5: fdbf73cac03fdc051be700da11779b60
+  depends:
+  - python >=3.9
+  - python
+  channel: https://fast.prefix.dev/conda-forge
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/orderly-set?source=hash-mapping
+  size: 18526
+  timestamp: 1746626574918
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-h5888daf_8.conda
   sha256: 2c32fc459cabed3b272b3d41c63a869de3bee69636dee39519005fbc3e9c7b64
   md5: 81554d1604c59c8eabf592eacd1f561a

--- a/pixi.toml
+++ b/pixi.toml
@@ -60,6 +60,7 @@ catkin_tools = "*"
 rosdep = "*"
 colcon-common-extensions = ">=0.3.0,<0.4"
 setuptools = "<=58.2.0"
+deepdiff = "*"
 
 [feature.humble.activation]
 scripts = ["colcon_ws/install/setup.bash"]
@@ -68,6 +69,7 @@ scripts = ["colcon_ws/install/setup.bash"]
 ros_client_build = { cmd = "bash scripts/pixi_build_ros2_client.bash", outputs = ["colcon_ws/install/setup.bash"] }
 ros_client = { cmd = "ros2 run geoscenario_client geoscenario_client", depends-on = ["ros_client_build"] }
 ros_client_wgs84 = { cmd = "ros2 run geoscenario_client geoscenario_client --ros-args -p wgs84:=true", depends-on = ["ros_client_build"] }
+ros_client_wgs84_roundtriptest = { cmd = "ros2 run geoscenario_client geoscenario_client --ros-args -p wgs84:=true -p roundtriptest:=true", depends-on = ["ros_client_build"] }
 ros_mock_co_simulator = { cmd = "ros2 run geoscenario_client mock_co_simulator", depends-on = ["ros_client_build"] }
 rqt = "rqt"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -67,6 +67,7 @@ scripts = ["colcon_ws/install/setup.bash"]
 [feature.humble.tasks]
 ros_client_build = { cmd = "bash scripts/pixi_build_ros2_client.bash", outputs = ["colcon_ws/install/setup.bash"] }
 ros_client = { cmd = "ros2 run geoscenario_client geoscenario_client", depends-on = ["ros_client_build"] }
+ros_client_wgs84 = { cmd = "ros2 run geoscenario_client geoscenario_client --ros-args -p wgs84:=true", depends-on = ["ros_client_build"] }
 ros_mock_co_simulator = { cmd = "ros2 run geoscenario_client mock_co_simulator", depends-on = ["ros_client_build"] }
 rqt = "rqt"
 

--- a/scenarios/long_test_scenarios/gs_ringroad_stress_loop.osm
+++ b/scenarios/long_test_scenarios/gs_ringroad_stress_loop.osm
@@ -24,6 +24,7 @@
   </node>
   <node id='-5149173' action='modify' visible='true' lat='43.4681668322' lon='-80.5436763174'>
     <tag k='gs' v='origin' />
+    <tag k='altitude' v='298' />
   </node>
   <node id='-5149174' action='modify' visible='true' lat='43.47439847793' lon='-80.54246962216' />
   <node id='-5149175' action='modify' visible='true' lat='43.47268272607' lon='-80.54813411343' />

--- a/scripts/pixi_test_ros2_client.bash
+++ b/scripts/pixi_test_ros2_client.bash
@@ -3,10 +3,15 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR=$(dirname "$SCRIPT_DIR")
 
+WGS84=
+if [[ "$1" == "--wgs84" ]]; then
+    WGS84="_wgs84"
+fi
+
 cd ${REPO_DIR}
 pixi run -e humble ros_client_build
 pixi run -e humble rqt &
-pixi run -e humble ros_client &
+pixi run -e humble ros_client${WGS84} &
 pixi run -e humble ros_mock_co_simulator &
 
 shutdown_nodes() {

--- a/scripts/pixi_test_ros2_client.bash
+++ b/scripts/pixi_test_ros2_client.bash
@@ -3,15 +3,17 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR=$(dirname "$SCRIPT_DIR")
 
-WGS84=
+ROS_CLIENT="ros_client"
 if [[ "$1" == "--wgs84" ]]; then
-    WGS84="_wgs84"
+    ROS_CLIENT="${ROS_CLIENT}_wgs84"
+elif [[ "$1" == "--roundtriptest" ]]; then
+    ROS_CLIENT="${ROS_CLIENT}_wgs84_roundtriptest"
 fi
 
 cd ${REPO_DIR}
 pixi run -e humble ros_client_build
 pixi run -e humble rqt &
-pixi run -e humble ros_client${WGS84} &
+pixi run -e humble ${ROS_CLIENT} &
 pixi run -e humble ros_mock_co_simulator &
 
 shutdown_nodes() {


### PR DESCRIPTION
implements #178 

The ROS2 client can now optionally convert position and velocity to and from WGS84 coordinates.

Testing:
1. Default (local Cartesian frame defined using origin from geoscenario file)
```
bash scripts/pixi_test_ros2_client.bash
```
Observe that vehicle positions are in local cartesian coords.

2. WGS84 (origin=(0,0,0) and local coords converted)
```
bash scripts/pixi_test_ros2_client.bash --wgs84
```
Observe that vehicle positions are in lat/lon/alt.
3. Execute ROS2 client in round trip test mode:
```
bash scripts/pixi_test_ros2_client.bash --roundtriptest
```
Observe differences such as 
```
"root['y']": {'new_value': 490.5073000005382, 'old_value': 490.5073}, 
"root['vy']": {'new_value': 0.03279999806045453, 'old_value': 0.0328}
```
The DeepDiff is used with [`significant_digits=9`](https://zepworks.com/deepdiff/current/numbers.html#significant-digits) option.