### PR TITLE
Support Multiple Pedestrian and Vehicle Types in a Single Scenario

### DIFF
--- a/scenarios/test_scenarios/gs_all_vehicles_peds.osm
+++ b/scenarios/test_scenarios/gs_all_vehicles_peds.osm
@@ -1,0 +1,217 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5399540' action='modify' visible='true' lat='43.47126808505' lon='-80.53868466932' />
+  <node id='-5399541' action='modify' visible='true' lat='43.47121631997' lon='-80.53902060726'>
+    <tag k='btype' v='TV' />
+    <tag k='cycles' v='1' />
+    <tag k='goal_ends_simulation' v='no' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='traj_vehicle' />
+    <tag k='trajectory' v='vehicle_traj' />
+    <tag k='vid' v='3' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5399542' action='modify' visible='true' lat='43.47106979117' lon='-80.53874909577' />
+  <node id='-5399543' action='modify' visible='true' lat='43.47113282782' lon='-80.53885378876' />
+  <node id='-5399544' action='modify' visible='true' lat='43.47118334059' lon='-80.53884343451' />
+  <node id='-5399545' action='modify' visible='true' lat='43.47121882474' lon='-80.53880259274' />
+  <node id='-5399546' action='modify' visible='true' lat='43.4712497168' lon='-80.53875139672' />
+  <node id='-5399547' action='modify' visible='true' lat='43.47138434799' lon='-80.53922836761' />
+  <node id='-5399548' action='modify' visible='true' lat='43.47101969578' lon='-80.53876922904'>
+    <tag k='btype' v='PV' />
+    <tag k='cycles' v='1' />
+    <tag k='goal_ends_simulation' v='no' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='path_vehicle' />
+    <tag k='path' v='vehicle_path' />
+    <tag k='speed' v='10' />
+    <tag k='vid' v='2' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399549' action='modify' visible='true' lat='43.47107918447' lon='-80.53869204845'>
+    <tag k='btree' v='drive.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='goal_ends_simulation' v='yes' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='VUT' />
+    <tag k='route' v='left_route' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='217' />
+  </node>
+  <node id='-5399550' action='modify' visible='true' lat='43.47137559772' lon='-80.53871693233'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_ringroad_pedestrians.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='all vehicle and ped types' />
+    <tag k='timeout' v='30' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5399551' action='modify' visible='true' lat='43.47112606179' lon='-80.53877698841'>
+    <tag k='altitude' v='320' />
+    <tag k='area' v='500' />
+    <tag k='gs' v='origin' />
+    <tag k='name' v='origin' />
+  </node>
+  <node id='-5399552' action='modify' visible='true' lat='43.47136908261' lon='-80.53920272194'>
+    <tag k='gs' v='egogoal' />
+    <tag k='name' v='g1' />
+  </node>
+  <node id='-5399553' action='modify' visible='true' lat='43.47120838822' lon='-80.53899242068'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='0' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5399554' action='modify' visible='true' lat='43.47107928716' lon='-80.5386921751' />
+  <node id='-5399555' action='modify' visible='true' lat='43.47119001996' lon='-80.53890383431'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='2' />
+    <tag k='yaw' v='420' />
+  </node>
+  <node id='-5399556' action='modify' visible='true' lat='43.47110057653' lon='-80.53872858078' />
+  <node id='-5399557' action='modify' visible='true' lat='43.47111195477' lon='-80.53885206305'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='5' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5399558' action='modify' visible='true' lat='43.47110864745' lon='-80.53874256185' />
+  <node id='-5399559' action='modify' visible='true' lat='43.47110277062' lon='-80.5387145816'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='10' />
+    <tag k='time' v='10' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5399560' action='modify' visible='true' lat='43.47112674973' lon='-80.5387756924' />
+  <node id='-5399599' action='modify' visible='true' lat='43.47091002478' lon='-80.53862849214' />
+  <node id='-5399600' action='modify' visible='true' lat='43.47093055041' lon='-80.53857663587'>
+    <tag k='elevation' v='298.0' />
+  </node>
+  <node id='-5399601' action='modify' visible='true' lat='43.47096720441' lon='-80.53853426924' />
+  <node id='-5399602' action='modify' visible='true' lat='43.47102771599' lon='-80.53879260545'>
+    <tag k='btype' v='TP' />
+    <tag k='cycles' v='1' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='traj_ped' />
+    <tag k='pid' v='2' />
+    <tag k='trajectory' v='traj_1' />
+    <tag k='yaw' v='180' />
+  </node>
+  <node id='-5399603' action='modify' visible='true' lat='43.47100611011' lon='-80.53847416153' />
+  <node id='-5399604' action='modify' visible='true' lat='43.47102202607' lon='-80.53846197754'>
+    <tag k='btype' v='PP' />
+    <tag k='cycles' v='1' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='test_pp' />
+    <tag k='path' v='test_path_1' />
+    <tag k='pid' v='1' />
+    <tag k='speed' v='10' />
+    <tag k='start' v='yes' />
+    <tag k='yaw' v='240' />
+  </node>
+  <node id='-5399605' action='modify' visible='true' lat='43.47118679131' lon='-80.53886321388'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='10' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399606' action='modify' visible='true' lat='43.47115799581' lon='-80.53874252513'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='6' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399607' action='modify' visible='true' lat='43.47106361046' lon='-80.53869017156'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='4' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399608' action='modify' visible='true' lat='43.47102321668' lon='-80.53871111299'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='1' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399609' action='modify' visible='true' lat='43.47102561631' lon='-80.53878055035'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='0' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5399610' action='modify' visible='true' lat='43.47115370508' lon='-80.53874400973'>
+    <tag k='btree' v='walk.btree' />
+    <tag k='btype' v='SP' />
+    <tag k='destination' v='ped_2_dest' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='ped_1' />
+    <tag k='pid' v='4' />
+    <tag k='route' v='ped_2_route' />
+    <tag k='speed' v='5' />
+  </node>
+  <node id='-5399611' action='modify' visible='true' lat='43.47110513505' lon='-80.53880163623'>
+    <tag k='area' v='no' />
+    <tag k='continuous' v='no' />
+    <tag k='gs' v='location' />
+    <tag k='name' v='ped_2_dest' />
+  </node>
+  <node id='-5399612' action='modify' visible='true' lat='43.47115295625' lon='-80.53874509357' />
+  <node id='-5399613' action='modify' visible='true' lat='43.47112600203' lon='-80.53877813781' />
+  <way id='-1958140' action='modify' visible='true'>
+    <nd ref='-5399548' />
+    <nd ref='-5399542' />
+    <nd ref='-5399543' />
+    <nd ref='-5399544' />
+    <nd ref='-5399545' />
+    <nd ref='-5399546' />
+    <nd ref='-5399540' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='vehicle_path' />
+  </way>
+  <way id='-1958141' action='modify' visible='true'>
+    <nd ref='-5399554' />
+    <nd ref='-5399556' />
+    <nd ref='-5399558' />
+    <nd ref='-5399560' />
+    <nd ref='-5399547' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='left_route' />
+  </way>
+  <way id='-1958142' action='modify' visible='true'>
+    <nd ref='-5399553' />
+    <nd ref='-5399555' />
+    <nd ref='-5399557' />
+    <nd ref='-5399559' />
+    <tag k='gs' v='trajectory' />
+    <tag k='name' v='vehicle_traj' />
+  </way>
+  <way id='-1958155' action='modify' visible='true'>
+    <nd ref='-5399603' />
+    <nd ref='-5399601' />
+    <nd ref='-5399600' />
+    <nd ref='-5399599' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='test_path_1' />
+  </way>
+  <way id='-1958156' action='modify' visible='true'>
+    <nd ref='-5399612' />
+    <nd ref='-5399613' />
+    <nd ref='-5399611' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='ped_2_route' />
+  </way>
+  <way id='-1958157' action='modify' visible='true'>
+    <nd ref='-5399609' />
+    <nd ref='-5399608' />
+    <nd ref='-5399607' />
+    <nd ref='-5399606' />
+    <nd ref='-5399605' />
+    <tag k='gs' v='trajectory' />
+    <tag k='name' v='traj_1' />
+  </way>
+</osm>

--- a/scenarios/test_scenarios/gs_pp_tp_sp.osm
+++ b/scenarios/test_scenarios/gs_pp_tp_sp.osm
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='JOSM'>
-  <node id='-5350665' action='modify' visible='true' lat='43.47187788496' lon='-80.53987683454'>
+  <node id='-5350665' action='modify' visible='true' lat='43.47112593493' lon='-80.53857814876'>
     <tag k='collision' v='yes' />
     <tag k='gs' v='globalconfig' />
     <tag k='lanelet' v='maps/lanelet2_ringroad_pedestrians.osm' />
@@ -9,12 +9,12 @@
     <tag k='timeout' v='60' />
     <tag k='version' v='2.0' />
   </node>
-  <node id='-5350666' action='modify' visible='true' lat='43.47176942209' lon='-80.53990648226'>
+  <node id='-5350666' action='modify' visible='true' lat='43.47101747071' lon='-80.53860779648'>
     <tag k='altitude' v='300' />
     <tag k='area' v='100' />
     <tag k='gs' v='origin' />
   </node>
-  <node id='-5350672' action='modify' visible='true' lat='43.4717795014' lon='-80.54009029493'>
+  <node id='-5350672' action='modify' visible='true' lat='43.47102755015' lon='-80.53879160915'>
     <tag k='btype' v='TP' />
     <tag k='cycles' v='1' />
     <tag k='gs' v='pedestrian' />
@@ -23,7 +23,7 @@
     <tag k='trajectory' v='traj_1' />
     <tag k='yaw' v='180' />
   </node>
-  <node id='-5350767' action='modify' visible='true' lat='43.47177381155' lon='-80.53975966702'>
+  <node id='-5350767' action='modify' visible='true' lat='43.47102186023' lon='-80.53846098124'>
     <tag k='btype' v='PP' />
     <tag k='cycles' v='1' />
     <tag k='gs' v='pedestrian' />
@@ -34,42 +34,50 @@
     <tag k='start' v='yes' />
     <tag k='yaw' v='240' />
   </node>
-  <node id='-5350768' action='modify' visible='true' lat='43.47175789579' lon='-80.53977185101' />
-  <node id='-5350769' action='modify' visible='true' lat='43.47171899058' lon='-80.53983195872' />
-  <node id='-5350770' action='modify' visible='true' lat='43.47168233703' lon='-80.53987432535'>
+  <node id='-5350768' action='modify' visible='true' lat='43.47100594427' lon='-80.53847316523' />
+  <node id='-5350769' action='modify' visible='true' lat='43.47096703857' lon='-80.53853327294' />
+  <node id='-5350770' action='modify' visible='true' lat='43.47093038457' lon='-80.53857563957'>
     <tag k='elevation' v='298.0' />
   </node>
-  <node id='-5350771' action='modify' visible='true' lat='43.47166181165' lon='-80.53992618162' />
-  <node id='-5350782' action='modify' visible='true' lat='43.47177740175' lon='-80.54007823983'>
+  <node id='-5350771' action='modify' visible='true' lat='43.47090985894' lon='-80.53862749584' />
+  <node id='-5350782' action='modify' visible='true' lat='43.47102545047' lon='-80.53877955405'>
     <tag k='gs' v='tnode' />
     <tag k='speed' v='5' />
     <tag k='time' v='0' />
     <tag k='yaw' v='320' />
   </node>
-  <node id='-5350783' action='modify' visible='true' lat='43.47177500215' lon='-80.54000880247'>
+  <node id='-5350783' action='modify' visible='true' lat='43.47102305084' lon='-80.53871011669'>
     <tag k='gs' v='tnode' />
     <tag k='speed' v='5' />
     <tag k='time' v='1' />
     <tag k='yaw' v='320' />
   </node>
-  <node id='-5350784' action='modify' visible='true' lat='43.47181539542' lon='-80.53998786104'>
+  <node id='-5350784' action='modify' visible='true' lat='43.47106344462' lon='-80.53868917526'>
     <tag k='gs' v='tnode' />
     <tag k='speed' v='5' />
     <tag k='time' v='4' />
     <tag k='yaw' v='320' />
   </node>
-  <node id='-5350785' action='modify' visible='true' lat='43.4719097796' lon='-80.54004021461'>
-    <tag k='gs' v='tnode' />
+  <node id='-5350785' action='modify' visible='true' lat='43.47115782997' lon='-80.53874152883' />
+  <node id='-5350786' action='modify' visible='true' lat='43.47118662547' lon='-80.53886221758' />
+  <node id='-5396159' action='modify' visible='true' lat='43.47115353924' lon='-80.53874301343'>
+    <tag k='btree' v='walk_ensure_collision.btree' />
+    <tag k='btype' v='SP' />
+    <tag k='destination' v='ped_2_dest' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='ped_1' />
+    <tag k='pid' v='4' />
+    <tag k='route' v='ped_2_route' />
     <tag k='speed' v='5' />
-    <tag k='time' v='7' />
-    <tag k='yaw' v='320' />
   </node>
-  <node id='-5350786' action='modify' visible='true' lat='43.47193857474' lon='-80.54016090336'>
-    <tag k='gs' v='tnode' />
-    <tag k='speed' v='5' />
-    <tag k='time' v='10' />
-    <tag k='yaw' v='320' />
+  <node id='-5396160' action='modify' visible='true' lat='43.47110496921' lon='-80.53880063993'>
+    <tag k='area' v='no' />
+    <tag k='continuous' v='no' />
+    <tag k='gs' v='location' />
+    <tag k='name' v='ped_2_dest' />
   </node>
+  <node id='-5396161' action='modify' visible='true' lat='43.47115279041' lon='-80.53874409727' />
+  <node id='-5396162' action='modify' visible='true' lat='43.47112583619' lon='-80.53877714151' />
   <way id='-1953006' action='modify' visible='true'>
     <nd ref='-5350768' />
     <nd ref='-5350769' />
@@ -87,5 +95,13 @@
     <nd ref='-5350786' />
     <tag k='gs' v='trajectory' />
     <tag k='name' v='traj_1' />
+  </way>
+  <way id='-1957920' action='modify' visible='true'>
+    <nd ref='-5396161' />
+    <nd ref='-5396162' />
+    <nd ref='-5396160' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='ped_2_route' />
   </way>
 </osm>

--- a/scenarios/test_scenarios/gs_pp_tp_sp.osm
+++ b/scenarios/test_scenarios/gs_pp_tp_sp.osm
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5350665' action='modify' visible='true' lat='43.47187788496' lon='-80.53987683454'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_ringroad_pedestrians.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='gs_pp_tp_sp' />
+    <tag k='timeout' v='60' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5350666' action='modify' visible='true' lat='43.47176942209' lon='-80.53990648226'>
+    <tag k='altitude' v='300' />
+    <tag k='area' v='100' />
+    <tag k='gs' v='origin' />
+  </node>
+  <node id='-5350672' action='modify' visible='true' lat='43.4717795014' lon='-80.54009029493'>
+    <tag k='btype' v='TP' />
+    <tag k='cycles' v='1' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='traj_ped' />
+    <tag k='pid' v='2' />
+    <tag k='trajectory' v='traj_1' />
+    <tag k='yaw' v='180' />
+  </node>
+  <node id='-5350767' action='modify' visible='true' lat='43.47177381155' lon='-80.53975966702'>
+    <tag k='btype' v='PP' />
+    <tag k='cycles' v='1' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='name' v='test_pp' />
+    <tag k='path' v='test_path_1' />
+    <tag k='pid' v='1' />
+    <tag k='speed' v='10' />
+    <tag k='start' v='yes' />
+    <tag k='yaw' v='240' />
+  </node>
+  <node id='-5350768' action='modify' visible='true' lat='43.47175789579' lon='-80.53977185101' />
+  <node id='-5350769' action='modify' visible='true' lat='43.47171899058' lon='-80.53983195872' />
+  <node id='-5350770' action='modify' visible='true' lat='43.47168233703' lon='-80.53987432535'>
+    <tag k='elevation' v='298.0' />
+  </node>
+  <node id='-5350771' action='modify' visible='true' lat='43.47166181165' lon='-80.53992618162' />
+  <node id='-5350782' action='modify' visible='true' lat='43.47177740175' lon='-80.54007823983'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='0' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5350783' action='modify' visible='true' lat='43.47177500215' lon='-80.54000880247'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='1' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5350784' action='modify' visible='true' lat='43.47181539542' lon='-80.53998786104'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='4' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5350785' action='modify' visible='true' lat='43.4719097796' lon='-80.54004021461'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='7' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5350786' action='modify' visible='true' lat='43.47193857474' lon='-80.54016090336'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='10' />
+    <tag k='yaw' v='320' />
+  </node>
+  <way id='-1953006' action='modify' visible='true'>
+    <nd ref='-5350768' />
+    <nd ref='-5350769' />
+    <nd ref='-5350770' />
+    <nd ref='-5350771' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='test_path_1' />
+  </way>
+  <way id='-1953013' action='modify' visible='true'>
+    <nd ref='-5350782' />
+    <nd ref='-5350783' />
+    <nd ref='-5350784' />
+    <nd ref='-5350785' />
+    <nd ref='-5350786' />
+    <tag k='gs' v='trajectory' />
+    <tag k='name' v='traj_1' />
+  </way>
+</osm>

--- a/scenarios/test_scenarios/gs_pp_tp_sp.osm
+++ b/scenarios/test_scenarios/gs_pp_tp_sp.osm
@@ -58,8 +58,18 @@
     <tag k='time' v='4' />
     <tag k='yaw' v='320' />
   </node>
-  <node id='-5350785' action='modify' visible='true' lat='43.47115782997' lon='-80.53874152883' />
-  <node id='-5350786' action='modify' visible='true' lat='43.47118662547' lon='-80.53886221758' />
+  <node id='-5350785' action='modify' visible='true' lat='43.47115782997' lon='-80.53874152883'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='6' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5350786' action='modify' visible='true' lat='43.47118662547' lon='-80.53886221758'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='5' />
+    <tag k='time' v='10' />
+    <tag k='yaw' v='320' />
+  </node>
   <node id='-5396159' action='modify' visible='true' lat='43.47115353924' lon='-80.53874301343'>
     <tag k='btree' v='walk_ensure_collision.btree' />
     <tag k='btype' v='SP' />

--- a/scenarios/test_scenarios/gs_pv_tv_sdv.osm
+++ b/scenarios/test_scenarios/gs_pv_tv_sdv.osm
@@ -111,5 +111,7 @@
     <nd ref='-5396162' />
     <nd ref='-5396163' />
     <nd ref='-5396164' />
+    <tag k='gs' v='trajectory' />
+    <tag k='name' v='vehicle_traj' />
   </way>
 </osm>

--- a/scenarios/test_scenarios/gs_pv_tv_sdv.osm
+++ b/scenarios/test_scenarios/gs_pv_tv_sdv.osm
@@ -1,0 +1,115 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-5396126' action='modify' visible='true' lat='43.47107837329' lon='-80.53869313742'>
+    <tag k='btree' v='drive.btree' />
+    <tag k='btype' v='SDV' />
+    <tag k='goal_ends_simulation' v='yes' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='VUT' />
+    <tag k='route' v='left_route' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='217' />
+  </node>
+  <node id='-5396127' action='modify' visible='true' lat='43.47137478654' lon='-80.5387180213'>
+    <tag k='collision' v='yes' />
+    <tag k='gs' v='globalconfig' />
+    <tag k='lanelet' v='maps/lanelet2_ringroad_pedestrians.osm' />
+    <tag k='mutate' v='no' />
+    <tag k='name' v='Guarantee Collision Scenario' />
+    <tag k='timeout' v='30' />
+    <tag k='version' v='2.0' />
+  </node>
+  <node id='-5396128' action='modify' visible='true' lat='43.47112525061' lon='-80.53877807738'>
+    <tag k='altitude' v='320' />
+    <tag k='area' v='500' />
+    <tag k='gs' v='origin' />
+    <tag k='name' v='origin' />
+  </node>
+  <node id='-5396129' action='modify' visible='true' lat='43.47136827143' lon='-80.53920381091'>
+    <tag k='gs' v='egogoal' />
+    <tag k='name' v='g1' />
+  </node>
+  <node id='-5396130' action='modify' visible='true' lat='43.47107847598' lon='-80.53869326407' />
+  <node id='-5396131' action='modify' visible='true' lat='43.47109976535' lon='-80.53872966975' />
+  <node id='-5396132' action='modify' visible='true' lat='43.47110783627' lon='-80.53874365082' />
+  <node id='-5396133' action='modify' visible='true' lat='43.47112593855' lon='-80.53877678137' />
+  <node id='-5396134' action='modify' visible='true' lat='43.47138353681' lon='-80.53922945658' />
+  <node id='-5396135' action='modify' visible='true' lat='43.4710188846' lon='-80.53877031801'>
+    <tag k='btype' v='PV' />
+    <tag k='cycles' v='1' />
+    <tag k='goal_ends_simulation' v='no' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='path_vehicle' />
+    <tag k='path' v='vehicle_path' />
+    <tag k='speed' v='10' />
+    <tag k='vid' v='1' />
+    <tag k='yaw' v='320' />
+  </node>
+  <node id='-5396145' action='modify' visible='true' lat='43.47106897999' lon='-80.53875018474' />
+  <node id='-5396146' action='modify' visible='true' lat='43.47113201664' lon='-80.53885487773' />
+  <node id='-5396147' action='modify' visible='true' lat='43.47118252941' lon='-80.53884452348' />
+  <node id='-5396148' action='modify' visible='true' lat='43.47121801356' lon='-80.53880368171' />
+  <node id='-5396149' action='modify' visible='true' lat='43.47124890562' lon='-80.53875248569' />
+  <node id='-5396150' action='modify' visible='true' lat='43.47126727387' lon='-80.53868575829' />
+  <node id='-5396152' action='modify' visible='true' lat='43.47121550879' lon='-80.53902169623'>
+    <tag k='btype' v='TV' />
+    <tag k='cycles' v='1' />
+    <tag k='goal_ends_simulation' v='no' />
+    <tag k='gs' v='vehicle' />
+    <tag k='name' v='traj_vehicle' />
+    <tag k='trajectory' v='vehicle_traj' />
+    <tag k='vid' v='3' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5396161' action='modify' visible='true' lat='43.47120757704' lon='-80.53899350965'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='0' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5396162' action='modify' visible='true' lat='43.47118920878' lon='-80.53890492328'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='2' />
+    <tag k='yaw' v='420' />
+  </node>
+  <node id='-5396163' action='modify' visible='true' lat='43.47111114359' lon='-80.53885315202'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='6' />
+    <tag k='time' v='5' />
+    <tag k='yaw' v='380' />
+  </node>
+  <node id='-5396164' action='modify' visible='true' lat='43.47110195944' lon='-80.53871567057'>
+    <tag k='gs' v='tnode' />
+    <tag k='speed' v='10' />
+    <tag k='time' v='10' />
+    <tag k='yaw' v='380' />
+  </node>
+  <way id='-1957899' action='modify' visible='true'>
+    <nd ref='-5396130' />
+    <nd ref='-5396131' />
+    <nd ref='-5396132' />
+    <nd ref='-5396133' />
+    <nd ref='-5396134' />
+    <tag k='gs' v='route' />
+    <tag k='name' v='left_route' />
+  </way>
+  <way id='-1957900' action='modify' visible='true'>
+    <nd ref='-5396135' />
+    <nd ref='-5396145' />
+    <nd ref='-5396146' />
+    <nd ref='-5396147' />
+    <nd ref='-5396148' />
+    <nd ref='-5396149' />
+    <nd ref='-5396150' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='vehicle_path' />
+  </way>
+  <way id='-1957909' action='modify' visible='true'>
+    <nd ref='-5396161' />
+    <nd ref='-5396162' />
+    <nd ref='-5396163' />
+    <nd ref='-5396164' />
+  </way>
+</osm>

--- a/scenarios/test_scenarios/gs_pv_tv_sdv.osm
+++ b/scenarios/test_scenarios/gs_pv_tv_sdv.osm
@@ -42,7 +42,7 @@
     <tag k='name' v='path_vehicle' />
     <tag k='path' v='vehicle_path' />
     <tag k='speed' v='10' />
-    <tag k='vid' v='1' />
+    <tag k='vid' v='2' />
     <tag k='yaw' v='320' />
   </node>
   <node id='-5396145' action='modify' visible='true' lat='43.47106897999' lon='-80.53875018474' />

--- a/sp/Pedestrian.py
+++ b/sp/Pedestrian.py
@@ -301,6 +301,8 @@ class PP(Pedestrian):
         self.path = path
         self._debug_shdata = debug_shdata
         self.keep_active = keep_active
+        
+        self.current_waypoint = 0.0
 
         self.current_path_node = 0
     


### PR DESCRIPTION
## Summary

This PR introduces a fix that allows different combinations of pedestrian and vehicle types to be initialized and executed within the same simulation scenario. 

### NOTE!!
This is a temporary fix for now and a more robust one would be covered in a future PR

## Changes

- Add comprehensive test scenarios that cover a combination of all pedestrians, vehicles and pedestrians and vehicles
- Code fix to allow this

## Testing

Run following commands and confirm their output

```bash
pixi run gss -m ./scenarios/ -s ./scenarios/test_scenarios/gs_pp_tp_sp.osm
```
```bash
pixi run gss -m ./scenarios/ -s ./scenarios/test_scenarios/gs_pv_tv_sdv.osm
```
```bash
pixi run gss -m ./scenarios/ -s ./scenarios/test_scenarios/gs_all_vehicles_peds.osm
```