### PR TITLE
added ensured collision feature for car to car scenarios

### DIFF
--- a/ScenarioSetup.py
+++ b/ScenarioSetup.py
@@ -254,9 +254,16 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
             if 'path' not in vnode.tags:
                 log.error("PV {} requires a path".format(vid))
                 continue
-
+        
             p_name = vnode.tags['path']
             p_nodes = parser.paths[p_name].nodes
+            set_speed = vnode.tags.get('speed', 0)
+
+            if "collision_vehicle_vid" in vnode.tags:
+                collision_vid = vnode.tags['collision_vehicle_vid']
+            else:
+                collision_vid = None
+
             path = []
             path_length = 0.0
 
@@ -283,7 +290,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                 log.error("PV {} has no initial speed".format(vid))
                 continue
 
-            vehicle = PV(vid, name, start_state=start_state, frenet_state=frenet_state, yaw=yaw, path=path, debug_shdata=sim_traffic.debug_shdata, length=length, width=width)
+            vehicle = PV(vid, name, start_state=start_state, frenet_state=frenet_state, yaw=yaw, path=path, debug_shdata=sim_traffic.debug_shdata, length=length, width=width, collision_vid=collision_vid, scenario_vehicles=sim_traffic.vehicles, set_speed=set_speed)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
             log.info("Vehicle {} initialized with PV behavior".format(vid))

--- a/util/Utils.py
+++ b/util/Utils.py
@@ -241,3 +241,6 @@ def point_in_rectangle(P, A, B, C, D):
     inside_rect = first_two and last_two
 
     return inside_rect
+
+def normalize_angle(angle):
+        return angle % (2 * np.pi)


### PR DESCRIPTION
Adding the feature of ensuring car to car collision scenarios for the NCAP standard. 

The algorithm is similar to the ensured collision between pedestrian and car, but instead of adjusting the speed of the pedestrian to ensure the collision, a "released" feature is in place instead. 

The path vehicle is to travel only at the set speed outlined by the NCAP document, therefore, prior to releasing the global vehicle target (GVT), the vehicle will be at rest. Once the collision point is found as well as the time to collision is set, the GVT will start to move at the set speed to ensure the collision at the collision point. 

To test, set the GVT's profile in the .osm to include "collision_vehicle_vid = <desired collision vehicle>"

A good scenario to test would be from the NCAP document (NCAP_CCCscp)  