### PR TITLE
add ros_client_build_release task to allow --merge-install

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -66,7 +66,8 @@ deepdiff = "*"
 scripts = ["colcon_ws/install/setup.bash"]
 
 [feature.humble.tasks]
-ros_client_build = { cmd = "bash scripts/pixi_build_ros2_client.bash", outputs = ["colcon_ws/install/setup.bash"] }
+ros_client_build = { cmd = "bash scripts/pixi_build_ros2_client.bash --symlink-install", outputs = ["colcon_ws/install/setup.bash"] }
+ros_client_build_release = { cmd = "bash scripts/pixi_build_ros2_client.bash", outputs = ["colcon_ws/install/setup.bash"] }
 ros_client = { cmd = "ros2 run geoscenario_client geoscenario_client", depends-on = ["ros_client_build"] }
 ros_client_wgs84 = { cmd = "ros2 run geoscenario_client geoscenario_client --ros-args -p wgs84:=true", depends-on = ["ros_client_build"] }
 ros_client_wgs84_roundtriptest = { cmd = "ros2 run geoscenario_client geoscenario_client --ros-args -p wgs84:=true -p roundtriptest:=true", depends-on = ["ros_client_build"] }

--- a/scripts/pixi_build_ros2_client.bash
+++ b/scripts/pixi_build_ros2_client.bash
@@ -5,4 +5,4 @@ REPO_DIR=$(dirname "$SCRIPT_DIR")
 mkdir -p ${REPO_DIR}/colcon_ws/src
 ln -sfn ${REPO_DIR}/clients/ros2_client ${REPO_DIR}/colcon_ws/src/ros2_client
 cd ${REPO_DIR}/colcon_ws
-colcon build --symlink-install
+colcon build $@


### PR DESCRIPTION
The task `ros_client_build` uses a symlinked layout ( `colcon build --symlink-install` ) for the ease of development. 
However, for deployment we want to be able to have the install space with copied files. 

To support that, we're adding a new task `ros_client_build_release`, which allows passing arguments to the colcon build.

In order to build with the default (aka "isolated") colcon workspace layout, execute
`pixi run ros_client_build_release`.

In order to build with the merged colcon workspace layout, execute
`pixi run ros_client_build_release --merge-install`.

For more information, see [workspace layout](https://colcon.readthedocs.io/en/released/user/isolated-vs-merged-workspaces.html).