### PR TITLE
Change default speed qualifier behavior to initial

### DIFF
--- a/Actor.py
+++ b/Actor.py
@@ -192,7 +192,7 @@ class Actor(object):
         if path:
             # Which path node have we most recently passed
             node_checkpoint = 0
-            speed_qualifier_enum = SpeedQualifier[speed_qualifier.upper()] if speed_qualifier is not None else SpeedQualifier.CONSTANT
+            speed_qualifier_enum = SpeedQualifier[speed_qualifier.upper()] if speed_qualifier is not None else SpeedQualifier.INITIAL
             # Ideally we should first calculate acceleration, then velocity, then position (euler integration)
             # For now, we'll ignore acceleration
             # TODO: This could be improved by saving the current path node instead of having to find it again every tick


### PR DESCRIPTION
Bug fix according to [discussion](https://github.com/rodrigoqueiroz/geoscenarioserver/pull/187#issuecomment-3349012309) in PR #187.

Below tests should work as expected now since behavior defaults to `initial` without mention of speed_qualifier in osm files.

## Tests

### 1. VUT stops during collision test
Pedestrian should stop as well.
```bash
pixi run gss -s scenarios/test_scenarios/gs_forced_collision_test_vehicle_pause.osm
```

### 2. Multiple Vehicles Test

```bash
pixi run gss -s scenarios/test_scenarios/gs_forced_collision_test_multiple_vehicles.osm
```

Modify the .osm file to set different collision_vehicle_vid values:
