### PR TITLE
Allow cosim to send only updated vehicles

### DIFF
--- a/ros2/src/geoscenario_client/geoscenario_client/mock_co_simulator.py
+++ b/ros2/src/geoscenario_client/geoscenario_client/mock_co_simulator.py
@@ -88,16 +88,21 @@ class MockCoSimulator(Node):
         return True
 
     def tick_from_server(self, msg):
-        # Update external vehicle positions using circular motion
+        # Only send EV vehicles that we're updating (partial agent list)
+        updated_vehicles = []
         for v in msg.vehicles:
-            v.active = True
             if v.type == '2': # EV_TYPE
+                v.active = True
                 # Update position (circular motion pattern)
                 v.position.x -= math.sin(msg.simulation_time)
                 v.position.y += math.cos(msg.simulation_time)
+                updated_vehicles.append(v)
 
-        for p in msg.pedestrians:
-            p.active = True
+        # Replace full list with only updated vehicles
+        msg.vehicles = updated_vehicles
+
+        # Don't send pedestrians since we're not updating any
+        msg.pedestrians = []
 
         # Determine publishing strategy based on control mode
         if self.target_dt <= 0.0:

--- a/ros2/src/geoscenario_server/geoscenario_server/geoscenario_server.py
+++ b/ros2/src/geoscenario_server/geoscenario_server/geoscenario_server.py
@@ -217,23 +217,7 @@ class GSServer(Node, GSServerBase):
 
 
     def tick_from_client(self, msg):
-        # Validate message counts match expected actors
-        # Protocol sends/receives ALL actors (not just EV/EP), but only EV/EP are updated
-        expected_vehicle_count = len(self.traffic.vehicles)
-        expected_pedestrian_count = len(self.traffic.pedestrians)
-
-        if len(msg.vehicles) != expected_vehicle_count:
-            self.get_logger().warn(
-                f'Vehicle count mismatch: expected {expected_vehicle_count} total vehicles, '
-                f'got {len(msg.vehicles)} in message'
-            )
-
-        if len(msg.pedestrians) != expected_pedestrian_count:
-            self.get_logger().warn(
-                f'Pedestrian count mismatch: expected {expected_pedestrian_count} total pedestrians, '
-                f'got {len(msg.pedestrians)} in message'
-            )
-
+        # Process incoming tick - only EV/EP types are updated from client messages
         if msg.tick_count != self.tick_count + 1:
             self.get_logger().error(
                 f'Tick count mismatch: expected {self.tick_count + 1}, '


### PR DESCRIPTION
Allows co-simulator to send any number of agent in it's tick message, ROS server will assume no change for the agent