### PR TITLE
Consolidate logging into ROS2 logs for ROS server

### DIFF
--- a/ros2/src/geoscenario_server/geoscenario_server/geoscenario_server.py
+++ b/ros2/src/geoscenario_server/geoscenario_server/geoscenario_server.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Any
 import os
 
-
 import rclpy
 from rclpy.node import Node
 from rclpy.executors import ExternalShutdownException
@@ -15,6 +14,7 @@ from geoscenarioserver.SimTraffic import SimTraffic
 from geoscenarioserver.Actor import VehicleState
 from geoscenarioserver.sv.Vehicle import Vehicle
 from geoscenarioserver.requirements.RequirementViolationEvents import GlobalTick, ScenarioCompletion, ScenarioTimeout
+from geoscenario_server.ros2_logging_handler import setup_ros2_logging, cleanup_ros2_logging
 
 from geoscenario_msgs.msg import Tick, Pedestrian as PedestrianMsg, Vehicle as VehicleMsg
 import math
@@ -49,6 +49,8 @@ class GSServer(Node, GSServerBase):
         for param in parameters:
             param_descriptor = ParameterDescriptor(type=param.type, description=param.description)
             self.declare_parameter(param.name, param.default_value, param_descriptor)
+
+        self._ros2_log_handler = setup_ros2_logging(self)
 
         self.tick_count = 0
         self.simulation_time = 0.0
@@ -154,6 +156,9 @@ class GSServer(Node, GSServerBase):
         # Quit dashboard if running
         if self.dashboard:
             self.dashboard.quit()
+
+        if hasattr(self, '_ros2_log_handler'):
+            cleanup_ros2_logging(self._ros2_log_handler)
 
         self.destroy_node()
         rclpy.try_shutdown()

--- a/ros2/src/geoscenario_server/geoscenario_server/ros2_logging_handler.py
+++ b/ros2/src/geoscenario_server/geoscenario_server/ros2_logging_handler.py
@@ -1,0 +1,74 @@
+"""
+ROS2 Logging Handler - Routes Python logging to ROS2 logger.
+
+Based on: https://robotics.stackexchange.com/questions/114497/logging-from-non-ros-components-without-access-to-node
+"""
+
+import logging
+from rclpy.logging import LoggingSeverity
+
+# Mapping between ROS2 LoggingSeverity and Python logging levels
+_ROS2_TO_PYTHON = {
+    LoggingSeverity.DEBUG: logging.DEBUG,
+    LoggingSeverity.INFO: logging.INFO,
+    LoggingSeverity.WARN: logging.WARNING,
+    LoggingSeverity.ERROR: logging.ERROR,
+    LoggingSeverity.FATAL: logging.CRITICAL,
+}
+_PYTHON_TO_ROS2 = {v: k for k, v in _ROS2_TO_PYTHON.items()}
+
+
+class ROS2LoggingHandler(logging.Handler):
+    """Forwards Python log records to a ROS2 node's logger."""
+
+    def __init__(self, node, level=logging.NOTSET):
+        super().__init__(level)
+        self._node_logger = node.get_logger()
+        self.setFormatter(logging.Formatter("[%(name)s] %(message)s"))
+
+    def emit(self, record):
+        msg = self.format(record)
+        ros2_level = _PYTHON_TO_ROS2.get(record.levelno)
+        if ros2_level is None:
+            # Find closest match for non-standard levels
+            for py_level in sorted(_PYTHON_TO_ROS2.keys(), reverse=True):
+                if record.levelno >= py_level:
+                    ros2_level = _PYTHON_TO_ROS2[py_level]
+                    break
+            else:
+                ros2_level = LoggingSeverity.DEBUG
+
+        if ros2_level == LoggingSeverity.FATAL:
+            self._node_logger.fatal(msg)
+        elif ros2_level == LoggingSeverity.ERROR:
+            self._node_logger.error(msg)
+        elif ros2_level == LoggingSeverity.WARN:
+            self._node_logger.warning(msg)
+        elif ros2_level == LoggingSeverity.INFO:
+            self._node_logger.info(msg)
+        else:
+            self._node_logger.debug(msg)
+
+
+def setup_ros2_logging(node):
+    """Set up Python logging to route through ROS2's logger."""
+    ros2_level = node.get_logger().get_effective_level()
+    level = _ROS2_TO_PYTHON.get(ros2_level, logging.DEBUG)
+
+    handler = ROS2LoggingHandler(node, level)
+
+    root_logger = logging.getLogger()
+    for existing_handler in root_logger.handlers[:]:
+        if isinstance(existing_handler, logging.StreamHandler):
+            root_logger.removeHandler(existing_handler)
+
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+    return handler
+
+
+def cleanup_ros2_logging(handler):
+    """Remove the ROS2 logging handler from the root logger."""
+    root_logger = logging.getLogger()
+    if handler in root_logger.handlers:
+        root_logger.removeHandler(handler)


### PR DESCRIPTION
All logs within the same process as GSS ROS server are now processed through the ROS2 logging mechanism, allowing for the logs to be read through /rosout topic.

```
[INFO] [1764958309.478278443] [geoscenario_server]: [geoscenarioserver.sv.SDVPlanner] PLANNER PROCESS END. Vehicle1
[INFO] [1764958309.479526202] [geoscenario_server]: Scenario completed successfully: Vehicle under test reached its target
[INFO] [1764958309.479954119] [geoscenario_server]: Shutting down normally - simulation complete
[INFO] [1764958309.480422774] [geoscenario_server]: [geoscenarioserver.sv.SDVPlanner] Terminate planner process for VID: 1
```

Closes #203 