### PR TITLE
Support adult and child pedestrians

### DIFF
--- a/geoscenarioserver/Actor.py
+++ b/geoscenarioserver/Actor.py
@@ -24,11 +24,12 @@ class ActorSimState(IntEnum):
     INVISIBLE = 2         #in simulation but NOT visible to other agents (for reference)
 
 class Actor(object):
-    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, state=None, length=0.0, width=0.0):
+    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, state=None, length=0.0, width=0.0, height=0.0):
         self.id = id
         self.name = name
         self.length = length
         self.width = width
+        self.height = height
         self.radius = min(length, width) / 2.0
         self.sim_state = ActorSimState.ACTIVE
         self.type = None

--- a/geoscenarioserver/ScenarioSetup.py
+++ b/geoscenarioserver/ScenarioSetup.py
@@ -177,6 +177,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         start_in_frenet = False
         length = extract_tag(vnode, 'length', VEHICLE_LENGTH, float)
         width = extract_tag(vnode, 'width', VEHICLE_WIDTH, float)
+        height = extract_tag(vnode, 'height', VEHICLE_HEIGHT, float)
 
         #yaw = 90.0
         #if 'yaw' in vnode.tags:
@@ -244,7 +245,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
             try:
                 if not has_map:
                     # Create SDV without route when no map is loaded
-                    vehicle = Vehicle(vid, name, start_state, yaw=yaw, length=length, width=width)
+                    vehicle = Vehicle(vid, name, start_state, yaw=yaw, length=length, width=width, height=height)
                     vehicle.type = Vehicle.SDV_TYPE
                     vehicle.model = model
                     vehicle.sim_state = ActorSimState.INACTIVE
@@ -257,7 +258,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                                     btree_locations=btree_locations,
                                     btype=btype, goal_ends_simulation=goal_ends_simulation,
                                     rule_engine_port=rule_engine_port,
-                                    length=length, width=width
+                                    length=length, width=width, height=height
                                 )
                     #vehicle = SDV(  vid, name, root_btree_name, start_state, yaw,
                     #                lanelet_map, sim_config.lanelet_routes[vid],
@@ -309,7 +310,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                             start_state = start_state,                      #vehicle start state in cartesian frame [x,x_vel,x_acc, y,y_vel,y_acc]
                             yaw = yaw,
                             trajectory = trajectory,                        #a valid trajectory with at least x,y,time per node
-                            length=length, width=width)
+                            length=length, width=width, height=height)
                 sim_traffic.add_vehicle(vehicle)
                 log.info("Vehicle {} initialized with TV behavior".format(vid))
 
@@ -373,7 +374,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                 log.error("PV {} has no initial speed".format(vid))
                 continue
 
-            vehicle = PV(vid, name, start_state, frenet_state, yaw, path, sim_traffic.debug_shdata, sim_traffic.vehicles, length=length, width=width, set_speed=set_speed, speed_qualifier=speed_qualifier, collision_vid=collision_vid, collision_point=collision_point, use_speed_profile=use_speed_profile)
+            vehicle = PV(vid, name, start_state, frenet_state, yaw, path, sim_traffic.debug_shdata, sim_traffic.vehicles, length=length, width=width, height=height, set_speed=set_speed, speed_qualifier=speed_qualifier, collision_vid=collision_vid, collision_point=collision_point, use_speed_profile=use_speed_profile)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
             log.info(f"Vehicle {vid} initialized with PV behavior")
@@ -382,14 +383,14 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         # External Vehicle (EV)
         elif btype == 'ev':
             bsource = extract_tag(vnode, 'bsource', 'co-simulator', str)
-            vehicle = EV(vid, name, start_state, yaw, bsource)
+            vehicle = EV(vid, name, start_state, yaw, bsource, height=height)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
             log.info(f"Vehicle {vid} initialized as an external vehicle")
 
         # Neutral Vehicle
         else:
-            vehicle = Vehicle(vid, name, start_state, yaw=yaw)
+            vehicle = Vehicle(vid, name, start_state, yaw=yaw, height=height)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
             log.info(f"Vehicle {vid} initialized as a motionless vehicle")

--- a/geoscenarioserver/ScenarioSetup.py
+++ b/geoscenarioserver/ScenarioSetup.py
@@ -383,7 +383,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         # External Vehicle (EV)
         elif btype == 'ev':
             bsource = extract_tag(vnode, 'bsource', 'co-simulator', str)
-            vehicle = EV(vid, name, start_state, yaw, bsource, height=height)
+            vehicle = EV(vid, name, start_state, yaw, bsource)
             vehicle.model = model
             sim_traffic.add_vehicle(vehicle)
             log.info(f"Vehicle {vid} initialized as an external vehicle")

--- a/geoscenarioserver/ScenarioSetup.py
+++ b/geoscenarioserver/ScenarioSetup.py
@@ -414,6 +414,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
         btype = pnode.tags['btype'].lower() if 'btype' in pnode.tags else ''
         length = extract_tag(pnode, 'length', PEDESTRIAN_LENGTH, float)
         width = extract_tag(pnode, 'width', PEDESTRIAN_WIDTH, float)
+        height = extract_tag(pnode, 'height', PEDESTRIAN_HEIGHT, float)
 
         # Trajectory Pedestrian (TP)
         if btype == 'tp':
@@ -442,7 +443,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                     nd.speed = float(node.tags['speed']) if 'speed' in node.tags else None
                     trajectory.append(nd)
                     prev_node = nd
-                pedestrian = TP(pid, name, start_state, yaw, trajectory, length=length, width=width)
+                pedestrian = TP(pid, name, start_state, yaw, trajectory, length=length, width=width, height=height)
                 sim_traffic.add_pedestrian(pedestrian)
                 log.info(f"Pedestrian {pid} initialized with TP behavior")
             except Exception as e:
@@ -458,7 +459,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
             try:
                 if not has_map:
                     # Create SP without planner when no map is loaded
-                    pedestrian = Pedestrian(pid, name, start_state, yaw=yaw, length=length, width=width)
+                    pedestrian = Pedestrian(pid, name, start_state, yaw=yaw, length=length, width=width, height=height)
                     pedestrian.type = Pedestrian.SP_TYPE
                     pedestrian.sim_state = ActorSimState.INACTIVE
                     sim_traffic.add_pedestrian(pedestrian)
@@ -485,7 +486,8 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                                     root_btree_name,
                                     btree_locations=btree_locations,
                                     btype=btype,
-                                    length=length, width=width)
+                                    length=length, width=width,
+                                    height=height)
 
                     sim_traffic.add_pedestrian(pedestrian)
                     log.info(f"Pedestrian {pid} initialized with SP behavior")
@@ -558,6 +560,7 @@ def load_geoscenario_from_file(gsfiles, sim_traffic:SimTraffic, sim_config:SimCo
                 path=path,
                 scenario_vehicles=sim_traffic.vehicles,
                 debug_shdata=sim_traffic.debug_shdata,
+                height=height,
                 set_speed=set_speed,
                 reference_speed=frenet_state[1],
                 speed_qualifier=speed_qualifier,

--- a/geoscenarioserver/SimConfig.py
+++ b/geoscenarioserver/SimConfig.py
@@ -64,7 +64,8 @@ VEHICLE_HEIGHT = 1.5        #vehicle height in [m]
 PEDESTRIAN_RADIUS = 0.27
 PEDESTRIAN_LENGTH = 0.6
 PEDESTRIAN_WIDTH = 0.5
-PEDESTRIAN_HEIGHT = 1.8     #height is set to 1.8m for all pedestrians
+PEDESTRIAN_HEIGHT = 1.8        #height is set to 1.8m for all adult pedestrians
+CHILD_PEDESTRIAN_HEIGHT = 1.2  #height is set to 1.2m for all child pedestrians
 
 #Planning
 PLANNER_RATE = 5                 #Planner tick rate

--- a/geoscenarioserver/gsc/GSParser.py
+++ b/geoscenarioserver/gsc/GSParser.py
@@ -214,7 +214,7 @@ class GSParser(object):
 
     def check_vehicle(self, n):
         mandatory = {"gs","vid","name"}
-        optional = { "yaw","model","btype","trajectory","route","btree", "bsource", "eid",
+        optional = { "yaw","model","height","btype","trajectory","route","btree", "bsource", "eid",
                     "speed","path","cycles","usespeedprofile","start","group",}
         self.check_tags(n, mandatory, optional)
         self.check_uniquename(n)

--- a/geoscenarioserver/gsc/GSParser.py
+++ b/geoscenarioserver/gsc/GSParser.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree
 import re
 import geoscenarioserver.gsc.Utils as Utils
 from geoscenarioserver.gsc.Report import Report
-from geoscenarioserver.SimConfig import UNIQUE_GS_TAGS_PER_SCENARIO
+from geoscenarioserver.SimConfig import UNIQUE_GS_TAGS_PER_SCENARIO, PEDESTRIAN_HEIGHT, CHILD_PEDESTRIAN_HEIGHT
 
 # do we want the projection dependency here?
 from lanelet2.core import GPSPoint
@@ -188,6 +188,9 @@ class GSParser(object):
                     "speed","path","cycles","usespeedprofile","start","group", "collision_vehicle_vid", "speed_qualifier"}
         self.check_tags(n, mandatory, optional)
         self.check_uniquename(n)
+
+        model = str(n.tags.get("model", "")).strip().lower()
+        n.tags["height"] = CHILD_PEDESTRIAN_HEIGHT if model == "child" else PEDESTRIAN_HEIGHT
 
         #  Validate collision_vehicle_vid if present
         if "collision_vehicle_vid" in n.tags:

--- a/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
+++ b/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
@@ -194,6 +194,27 @@
     <tag k='time' v='1' />
     <tag k='yaw' v='0' />
   </node>
+  <node id='-5403257' action='modify' lat='43.47118297156' lon='-80.53906433855'>
+    <tag k='btype' v='PP' />
+    <tag k='collision_vehicle_vid' v='1' />
+    <tag k='cycles' v='1' />
+    <tag k='gs' v='pedestrian' />
+    <tag k='model' v='child' />
+    <tag k='name' v='Timmy' />
+    <tag k='path' v='p4p' />
+    <tag k='pid' v='4' />
+    <tag k='speed' v='3' />
+    <tag k='speed_qualifier' v='constant' />
+  </node>
+  <node id='-5403258' action='modify' lat='43.47128956351' lon='-80.53891518384' />
+  <node id='-5403319' action='modify' lat='43.47121354447' lon='-80.5390529527' />
+  <node id='-5403334' action='modify' lat='43.47124081218' lon='-80.53896755878' />
+  <node id='-5403349' action='modify' lat='43.47127386393' lon='-80.53897211312' />
+  <node id='-5403372' action='modify' lat='43.47127634282' lon='-80.53892201535' />
+  <node id='-5403457' action='modify' lat='43.47122759147' lon='-80.53903131957' />
+  <node id='-5403469' action='modify' lat='43.47122593888' lon='-80.538997162' />
+  <node id='-5403502' action='modify' lat='43.47125816435' lon='-80.53897439029' />
+  <node id='-5403510' action='modify' lat='43.47127716911' lon='-80.53895047999' />
   <way id='-1958163' action='modify'>
     <nd ref='-5399635' />
     <nd ref='-5399629' />
@@ -256,5 +277,20 @@
     <nd ref='-5399654' />
     <tag k='gs' v='trajectory' />
     <tag k='name' v='traj_1' />
+  </way>
+  <way id='-1958171' action='modify'>
+    <nd ref='-5403257' />
+    <nd ref='-5403319' />
+    <nd ref='-5403457' />
+    <nd ref='-5403469' />
+    <nd ref='-5403334' />
+    <nd ref='-5403502' />
+    <nd ref='-5403349' />
+    <nd ref='-5403510' />
+    <nd ref='-5403372' />
+    <nd ref='-5403258' />
+    <tag k='abstract' v='no' />
+    <tag k='gs' v='path' />
+    <tag k='name' v='p4p' />
   </way>
 </osm>

--- a/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
+++ b/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
@@ -27,6 +27,7 @@
     <tag k='speed' v='10' />
     <tag k='vid' v='2' />
     <tag k='yaw' v='320' />
+    <tag k='height' v='2' />
   </node>
   <node id='-5399636' action='modify' lat='43.47076127669' lon='-80.53842310773'>
     <tag k='btree' v='st_standard_driver.btree' />

--- a/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
+++ b/geoscenarioserver/scenarios/test_scenarios/gs_all_vehicles_peds.osm
@@ -205,7 +205,6 @@
     <tag k='path' v='p4p' />
     <tag k='pid' v='4' />
     <tag k='speed' v='3' />
-    <tag k='speed_qualifier' v='constant' />
   </node>
   <node id='-5403258' action='modify' lat='43.47128956351' lon='-80.53891518384' />
   <node id='-5403319' action='modify' lat='43.47121354447' lon='-80.5390529527' />

--- a/geoscenarioserver/sp/Pedestrian.py
+++ b/geoscenarioserver/sp/Pedestrian.py
@@ -31,8 +31,8 @@ class Pedestrian(Actor):
 
     VEHICLES_POS = {}
 
-    def __init__(self, id:int, name:str='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw:float=0.0, length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH):
-        super().__init__(id, name, start_state, frenet_state, yaw=yaw, length=length, width=width)
+    def __init__(self, id:int, name:str='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw:float=0.0, length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH, height:float=PEDESTRIAN_HEIGHT):
+        super().__init__(id, name, start_state, frenet_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Pedestrian.N_TYPE
 
     def update_sim_state(self, new_state, delta_time):
@@ -42,7 +42,7 @@ class Pedestrian(Actor):
 
 
     def get_sim_state(self):
-        dimensions = [self.length, self.width, PEDESTRIAN_HEIGHT]
+        dimensions = [self.length, self.width, self.height]
         position = [self.state.x, self.state.y, 0.0]
         velocity = [self.state.x_vel, self.state.y_vel]
         return self.id, self.type, dimensions, position, velocity, self.state.yaw
@@ -52,8 +52,8 @@ class TP(Pedestrian):
     A trajectory following pedestrian.
     @param keep_active: If True, pedestrian stays in simulation even when is not following a trajectory
     """
-    def __init__(self, id:int, name:str, start_state, yaw:float, trajectory, keep_active:bool = True, length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH):
-        super().__init__(id, name, start_state, yaw=yaw, length=length, width=width)
+    def __init__(self, id:int, name:str, start_state, yaw:float, trajectory, keep_active:bool = True, length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH, height:float=PEDESTRIAN_HEIGHT):
+        super().__init__(id, name, start_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Pedestrian.TP_TYPE
         self.trajectory = trajectory
         self.keep_active = keep_active
@@ -75,8 +75,8 @@ class SP(Pedestrian):
     of the Social Force Model (SFM) are informed by behaviour trees
     """
 
-    def __init__(self, id:int, name:str, start_state, yaw:float, goal_points, root_btree_name, btree_locations=[], btype="", length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH):
-        super().__init__(id, name, start_state, yaw=yaw, length=length, width=width)
+    def __init__(self, id:int, name:str, start_state, yaw:float, goal_points, root_btree_name, btree_locations=[], btype="", length:float=PEDESTRIAN_LENGTH, width:float=PEDESTRIAN_WIDTH, height:float=PEDESTRIAN_HEIGHT):
+        super().__init__(id, name, start_state, yaw=yaw, length=length, width=width, height=height)
         self.btype = btype
         self.btree_locations = btree_locations
         self.root_btree_name = root_btree_name
@@ -298,8 +298,8 @@ class PP(Pedestrian):
     """
     A path following pedestrian.
     """
-    def __init__(self, pid, name, start_state, frenet_state, yaw, path, debug_shdata, scenario_vehicles, keep_active = True, length = PEDESTRIAN_LENGTH, width = PEDESTRIAN_WIDTH, set_speed = None, speed_qualifier = SpeedQualifier.INITIAL, collision_vid = None, collision_point = None, reference_speed = None, use_speed_profile=False):
-        super().__init__(pid, name, start_state, frenet_state, yaw=yaw, length=length, width=width)
+    def __init__(self, pid, name, start_state, frenet_state, yaw, path, debug_shdata, scenario_vehicles, keep_active = True, length = PEDESTRIAN_LENGTH, width = PEDESTRIAN_WIDTH, height:float=PEDESTRIAN_HEIGHT, set_speed = None, speed_qualifier = SpeedQualifier.INITIAL, collision_vid = None, collision_point = None, reference_speed = None, use_speed_profile=False):
+        super().__init__(pid, name, start_state, frenet_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Pedestrian.PP_TYPE
         self.configure_path_following(path, set_speed, speed_qualifier, collision_vid, collision_point, keep_active, use_speed_profile)
         self._debug_shdata = debug_shdata

--- a/geoscenarioserver/sv/Vehicle.py
+++ b/geoscenarioserver/sv/Vehicle.py
@@ -34,7 +34,7 @@ class SDV(Vehicle):
             yaw:float, lanelet_map:LaneletMap, route_nodes:List[Node],
             start_state_in_frenet:bool=False, btree_locations:List[str]=[], btype:str="",
             goal_ends_simulation:bool=False, rule_engine_port:int=None,
-            length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH):
+            length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, height:float=VEHICLE_HEIGHT):
         self.btype = btype
         self.btree_locations = btree_locations
         self.goal_ends_simulation    = goal_ends_simulation
@@ -49,7 +49,7 @@ class SDV(Vehicle):
             )
             self.sdv_route.update_reference_path(start_state[0])
             start_state[0] = 0.0
-            super().__init__(vid, name, start_state=(x_vector+y_vector), frenet_state=start_state, yaw=yaw, length=length, width=width)
+            super().__init__(vid, name, start_state=(x_vector+y_vector), frenet_state=start_state, yaw=yaw, length=length, width=width, height=height)
         else:
             self.sdv_route = SDVRoute(lanelet_map, start_state[0], start_state[3], route_nodes = route_nodes)
             s_vector, d_vector = sim_to_frenet_frame(
@@ -57,7 +57,7 @@ class SDV(Vehicle):
             )
             self.sdv_route.update_reference_path(s_vector[0])
             s_vector[0] = 0.0
-            super().__init__(vid, name, start_state=start_state, frenet_state=(s_vector + d_vector), yaw=yaw, length=length, width=width)
+            super().__init__(vid, name, start_state=start_state, frenet_state=(s_vector + d_vector), yaw=yaw, length=length, width=width, height=height)
 
         self.type = Vehicle.SDV_TYPE
 
@@ -229,8 +229,8 @@ class EV(Vehicle):
     """
     An external vehicle (remote simulation)
     """
-    def __init__(self, vid, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, bsource='', length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH):
-        super().__init__(vid, name, start_state, yaw=yaw, length=length, width=width)
+    def __init__(self, vid, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, bsource='', length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, height:float=VEHICLE_HEIGHT):
+        super().__init__(vid, name, start_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Vehicle.EV_TYPE
         self.P = np.identity(2) * 0.5 # some large error
         self.bsource = bsource
@@ -296,8 +296,8 @@ class TV(Vehicle):
     A trajectory following vehicle.
     @param keep_active: If True, vehicle stays in simulation even when is not following a trajectory
     """
-    def __init__(self, vid, name, start_state, yaw, trajectory, keep_active = True, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH):
-        super().__init__(vid, name, start_state, yaw=yaw, length=length, width=width)
+    def __init__(self, vid, name, start_state, yaw, trajectory, keep_active = True, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, height:float=VEHICLE_HEIGHT):
+        super().__init__(vid, name, start_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Vehicle.TV_TYPE
         self.trajectory = trajectory
         self.keep_active = keep_active
@@ -324,8 +324,8 @@ class PV(Vehicle):
     - agentacceleration (not implemented)
     - timetoacceleration (not implemented)
     """
-    def __init__(self, vid, name, start_state, frenet_state, yaw, path, debug_shdata, scenario_vehicles, keep_active = True, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, set_speed=None, speed_qualifier=SpeedQualifier.INITIAL, collision_vid=None, collision_point=None, use_speed_profile=False):
-        super().__init__(vid, name, start_state, frenet_state, yaw=yaw, length=length, width=width)
+    def __init__(self, vid, name, start_state, frenet_state, yaw, path, debug_shdata, scenario_vehicles, keep_active = True, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, height:float=VEHICLE_HEIGHT, set_speed=None, speed_qualifier=SpeedQualifier.INITIAL, collision_vid=None, collision_point=None, use_speed_profile=False):
+        super().__init__(vid, name, start_state, frenet_state, yaw=yaw, length=length, width=width, height=height)
         self.type = Vehicle.PV_TYPE
         self.configure_path_following(path, set_speed, speed_qualifier, collision_vid, collision_point, keep_active, use_speed_profile)
         self._debug_shdata = debug_shdata

--- a/geoscenarioserver/sv/VehicleBase.py
+++ b/geoscenarioserver/sv/VehicleBase.py
@@ -13,8 +13,8 @@ class Vehicle(Actor):
     TV_TYPE = 3
     PV_TYPE = 4
 
-    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH):
-        super().__init__(id, name, start_state, frenet_state, yaw, VehicleState(), length=length, width=width)
+    def __init__(self, id, name='', start_state=[0.0,0.0,0.0, 0.0,0.0,0.0], frenet_state=[0.0,0.0,0.0, 0.0,0.0,0.0], yaw=0.0, length:float=VEHICLE_LENGTH, width:float=VEHICLE_WIDTH, height:float=VEHICLE_HEIGHT):
+        super().__init__(id, name, start_state, frenet_state, yaw, VehicleState(), length=length, width=width, height=height)
         self.model  = ''
         self.type   = Vehicle.N_TYPE
 
@@ -27,7 +27,7 @@ class Vehicle(Actor):
 
 
     def get_sim_state(self):
-        dimensions = [self.length, self.width, VEHICLE_HEIGHT]
+        dimensions = [self.length, self.width, self.height]
         position = [self.state.x, self.state.y, 0.0]
         velocity = [self.state.x_vel, self.state.y_vel]
         return self.id, self.type, dimensions, position, velocity, self.state.yaw, self.state.steer

--- a/pixi.lock
+++ b/pixi.lock
@@ -40,7 +40,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
@@ -111,7 +111,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.88.1-h957473f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.88.1-h96a7f82_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_18.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
@@ -220,7 +220,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/geographiclib-cpp-2.7-hb700be7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-h040f060_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-hcfc306f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
@@ -287,7 +287,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
@@ -1000,8 +1000,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h5110415_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-h040f060_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h435ced3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-hcfc306f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.3.0-h96af755_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
@@ -1094,7 +1094,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
@@ -2555,8 +2555,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gfortran_linux-64-14.3.0-h6b77fdb_24.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h5110415_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-h040f060_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h435ced3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-hcfc306f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.3.0-h96af755_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
@@ -2655,7 +2655,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
@@ -6608,17 +6608,17 @@ packages:
   license_family: BSD
   size: 484212
   timestamp: 1766373411104
-- conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h5110415_0.conda
-  sha256: c5126215e644dc1358d53153477b054c95bea72b1c72b8a7940224e51cd21855
-  md5: 2ec5e3e179440179c28c974c8c3fe984
+- conda: https://prefix.dev/conda-forge/linux-64/glib-2.88.1-h435ced3_1.conda
+  sha256: 3afa29fc042f3c6c6b54165ed085f3e5516b5fac37b429b2b7c01913e5604412
+  md5: 7d844a122c6cf1d8d2fb024f85757225
   depends:
   - python *
   - packaging
-  - libglib ==2.88.1 h6705ce6_0
-  - glib-tools ==2.88.1 h040f060_0
+  - libglib ==2.88.1 h0d30a3d_1
+  - glib-tools ==2.88.1 hcfc306f_1
   license: LGPL-2.1-or-later
-  size: 85524
-  timestamp: 1777848149975
+  size: 85466
+  timestamp: 1777904907738
 - conda: https://prefix.dev/conda-forge/linux-aarch64/glib-2.86.4-hc66a092_1.conda
   sha256: 5a5d7cc6e687ef619ff9d652f142308ac3a826c37284050c5d6632638cfd4bdc
   md5: b234a527dc6734518a19a17331c11825
@@ -6630,17 +6630,17 @@ packages:
   license: LGPL-2.1-or-later
   size: 88045
   timestamp: 1771863290314
-- conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-h040f060_0.conda
-  sha256: edeabb898f3ab893473f9eb6ec0a072337f6e81a5bc4f91ac1387aae40698058
-  md5: 55e7cea32f68a173635bcd4ea3d6e02c
+- conda: https://prefix.dev/conda-forge/linux-64/glib-tools-2.88.1-hcfc306f_1.conda
+  sha256: 628015696c106665ae0043f7e9f51298ec9e8f11573734ad67a849c8279cbe33
+  md5: ff216b19c24f3a46e9d17ebcf2f96390
   depends:
-  - libglib ==2.88.1 h6705ce6_0
+  - libglib ==2.88.1 h0d30a3d_1
   - libffi
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: LGPL-2.1-or-later
-  size: 237210
-  timestamp: 1777848149975
+  size: 237141
+  timestamp: 1777904907738
 - conda: https://prefix.dev/conda-forge/linux-aarch64/glib-tools-2.86.4-hc87f4d4_1.conda
   sha256: bdb36755b6a9751ca26bc5a6fcd36747c1e2301a7aacdf08780da6338d7d09ad
   md5: 78005b6876d48531ed75c8986a6de7ad
@@ -8850,21 +8850,21 @@ packages:
   license: LicenseRef-libglvnd
   size: 113925
   timestamp: 1731331014056
-- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
-  sha256: d81bb2fd3b339009ddbf642c0569be1459ee0b9e5829d47651c0c0003c0e1ec8
-  md5: 42c424ab163c576c7fb5981f7fb379cf
+- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
+  sha256: a0899efbae2a6a9102c796c0b11ac371a3190da5afa28512eeb2879c65d1419c
+  md5: 6016ea5ee9e986bc683879408cc87529
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libzlib >=1.3.2,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - libffi >=3.5.2,<3.6.0a0
   - libiconv >=1.18,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
   - glib >2.66
   license: LGPL-2.1-or-later
-  size: 4754361
-  timestamp: 1777848149975
+  size: 4754370
+  timestamp: 1777904907738
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.86.4-hf53f6bf_1.conda
   sha256: afc503dbd04a5bf2709aa9d8318a03a8c4edb389f661ff280c3494bfef4341ec
   md5: 4ac4372fc4d7f20630a91314cdac8afd
@@ -8879,21 +8879,21 @@ packages:
   license: LGPL-2.1-or-later
   size: 4512186
   timestamp: 1771863220969
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.88.1-h957473f_0.conda
-  sha256: 7d2c07c43f5003e838b2eb3c270d2230a6a909e8f05100db580b6f11f527f44a
-  md5: b4f447af90e8fc91fd2939bbe8a5f5db
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.88.1-h96a7f82_1.conda
+  sha256: a02050346680c86f3f7ab0963d17508cf804a6eed2e451624f645173ceac7879
+  md5: dd38b87359ae701b4aa1ef74311edb59
   depends:
   - python 3.14.* *_cp314
   - libgcc >=14
   - libffi >=3.5.2,<3.6.0a0
+  - libiconv >=1.18,<2.0a0
   - libzlib >=1.3.2,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libiconv >=1.18,<2.0a0
   constrains:
   - glib >2.66
   license: LGPL-2.1-or-later
-  size: 4946773
-  timestamp: 1777848150657
+  size: 4946786
+  timestamp: 1777904911994
 - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
   md5: 8422fcc9e5e172c91e99aef703b3ce65


### PR DESCRIPTION
When `model='child'`, the pedestrian has with default `height=1.2`.

Added a child Timmy:
```
<node id='-5403257' action='modify' lat='43.47118297156' lon='-80.53906433855'>
    <tag k='btype' v='PP' />
    <tag k='collision_vehicle_vid' v='1' />
    <tag k='cycles' v='1' />
    <tag k='gs' v='pedestrian' />
    <tag k='model' v='child' />
    <tag k='name' v='Timmy' />
    <tag k='path' v='p4p' />
    <tag k='pid' v='4' />
    <tag k='speed' v='3' />
    <tag k='speed_qualifier' v='constant' />
</node>
```
to `test_scenarios/gs_all_vehicles_peds.osm`.

Additionally, it is possible to explicitly provide 
```
    <tag k='height' v='2' />
```
That was done for the path vehicle in the same test.

# Testing

Execute `bash test/test_ros2_client.bash` and observe in `rqt` that
1. adults (pid: 1-3) have height 1.8
2. child (pid: 4) has height 1.2
3. path vehicle (vid: 2)  has height 2.0